### PR TITLE
Update of schemes & scheme_types data sources (MNE)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: n2khab
 Title: Data preparation for Flemish Natura 2000 habitat analyses
-Version: 0.0.3.9000
+Version: 0.0.3.9010
 Authors@R: c(
     person("Floris", "Vanderhaeghe", 
             email = "floris.vanderhaeghe@inbo.be", 

--- a/inst/textdata/namelist.tsv
+++ b/inst/textdata/namelist.tsv
@@ -98,6 +98,7 @@ ATM_08.1	en	Atmospheric monitoring: environmental pressure 08.1_poll_air	ATM: 08
 ATM_101	en	Atmospheric monitoring: environmental pressure 101_clim_dry	ATM: 101_clim_dry
 ATM_102	en	Atmospheric monitoring: environmental pressure 102_clim_wet	ATM: 102_clim_wet
 BMF	en	Bogs, mires and fens	NA
+caves	en	caves	NA
 CD	en	Coastal sand dunes	NA
 CH	en	Coastal and halophytic habitats	NA
 CT	en	Calcareous type	NA
@@ -159,6 +160,7 @@ GW	en	Groundwater monitoring	NA
 GW_03.3	en	Groundwater monitoring: environmental pressure 03.3_eutr_gw	GW: 03.3_eutr_gw
 GW_04.2	en	Groundwater monitoring: environmental pressure 04.2_acidif_gw	GW: 04.2_acidif_gw
 GW_05.1_aq	en	Groundwater monitoring: environmental pressure 05.1_des_gw: partim aquatic	GW: 05.1_des_gw:  aq
+GW_05.1_caves	en	Groundwater monitoring: environmental pressure 05.1_des_gw: partim caves	GW: 05.1_des_gw:  caves
 GW_05.1_terr	en	Groundwater monitoring: environmental pressure 05.1_des_gw: partim terrestrial	GW: 05.1_des_gw:  terr
 GW_05.2	en	Groundwater monitoring: environmental pressure 05.2_wet_gw	GW: 05.2_wet_gw
 GW_07.1	en	Groundwater monitoring: environmental pressure 07.1_desal_gw	GW: 07.1_desal_gw
@@ -343,6 +345,7 @@ ATM_08.1	nl	Atmosferisch meetnet: milieudruk 08.1_verontr_atm	ATM: 08.1_verontr_
 ATM_101	nl	Atmosferisch meetnet: milieudruk 101_klim_droog	ATM: 101_klim_droog
 ATM_102	nl	Atmosferisch meetnet: milieudruk 102_klim_nat	ATM: 102_klim_nat
 BMF	nl	Moerassen	NA
+caves	nl	grotten	NA
 CD	nl	Kustduinen	NA
 CH	nl	Kust- en zilte habitats	NA
 CT	nl	Kalkrijkere (sub)types	NA
@@ -424,6 +427,7 @@ GW	nl	Grondwatermeetnet	NA
 GW_03.3	nl	Grondwatermeetnet: milieudruk 03.3_eutr_gw	GW: 03.3_eutr_gw
 GW_04.2	nl	Grondwatermeetnet: milieudruk 04.2_verzu_gw	GW: 04.2_verzu_gw
 GW_05.1_aq	nl	Grondwatermeetnet: milieudruk 05.1_verdro_gw: partim aquatisch	GW: 05.1_verdro_gw:  aq
+GW_05.1_caves	nl	Grondwatermeetnet: milieudruk 05.1_verdro_gw: partim grotten	GW: 05.1_verdro_gw:  caves
 GW_05.1_terr	nl	Grondwatermeetnet: milieudruk 05.1_verdro_gw: partim terrestrisch	GW: 05.1_verdro_gw:  terr
 GW_05.2	nl	Grondwatermeetnet: milieudruk 05.2_vernat_gw	GW: 05.2_vernat_gw
 GW_07.1	nl	Grondwatermeetnet: milieudruk 07.1_verzoet_gw	GW: 07.1_verzoet_gw

--- a/inst/textdata/namelist.tsv
+++ b/inst/textdata/namelist.tsv
@@ -93,7 +93,19 @@ code	lang	name	shortname
 aq	en	aquatic	NA
 ATM	en	Atmospheric monitoring	NA
 ATM_03.1	en	Atmospheric monitoring: environmental pressure 03.1_eutr_air	ATM: 03.1_eutr_air
+ATM_03.1_group1	en	very sensitive non-forest types	very sensitive non-forest
+ATM_03.1_group2	en	sensitive non-forest types	sensitive non-forest
+ATM_03.1_group3	en	less to not sensitive non-forest types	less/not sensitive non-forest
+ATM_03.1_group4	en	very sensitive forest types	very sensitive forest
+ATM_03.1_group5	en	sensitive forest types	sensitive forest
+ATM_03.1_group6	en	less to not sensitive forest types	less/not sensitive forest
 ATM_04.1	en	Atmospheric monitoring: environmental pressure 04.1_acidif_air	ATM: 04.1_acidif_air
+ATM_04.1_group1	en	very sensitive non-forest types	very sensitive non-forest
+ATM_04.1_group2	en	sensitive non-forest types	sensitive non-forest
+ATM_04.1_group3	en	less to not sensitive non-forest types	less/not sensitive non-forest
+ATM_04.1_group4	en	very sensitive forest types	very sensitive forest
+ATM_04.1_group5	en	sensitive forest types	sensitive forest
+ATM_04.1_group6	en	less to not sensitive forest types	less/not sensitive forest
 ATM_08.1	en	Atmospheric monitoring: environmental pressure 08.1_poll_air	ATM: 08.1_poll_air
 ATM_101	en	Atmospheric monitoring: environmental pressure 101_clim_dry	ATM: 101_clim_dry
 ATM_102	en	Atmospheric monitoring: environmental pressure 102_clim_wet	ATM: 102_clim_wet
@@ -158,10 +170,19 @@ FW	en	Fresh and brackish water	NA
 GR	en	Natural and semi-natural grassland	NA
 GW	en	Groundwater monitoring	NA
 GW_03.3	en	Groundwater monitoring: environmental pressure 03.3_eutr_gw	GW: 03.3_eutr_gw
+GW_03.3_group1	en	types from oligotrophic environments	oligotrophic
+GW_03.3_group2	en	types from mesotrophic environments	mesotrophic
+GW_03.3_group3	en	types from weakly eutrophic environments	weakly eutrophic
+GW_03.3_group4	en	types from moderately eutrophic to eutrophic environments	(moderately) eutrophic
 GW_04.2	en	Groundwater monitoring: environmental pressure 04.2_acidif_gw	GW: 04.2_acidif_gw
 GW_05.1_aq	en	Groundwater monitoring: environmental pressure 05.1_des_gw: partim aquatic	GW: 05.1_des_gw: aq
 GW_05.1_caves	en	Groundwater monitoring: environmental pressure 05.1_des_gw: partim caves	GW: 05.1_des_gw: caves
 GW_05.1_terr	en	Groundwater monitoring: environmental pressure 05.1_des_gw: partim terrestrial	GW: 05.1_des_gw: terr
+GW_05.1_terr_group1	en	types from very wet environments	very wet
+GW_05.1_terr_group2	en	types from wet environments	wet
+GW_05.1_terr_group3	en	types from moderately wet environments	moderately wet
+GW_05.1_terr_group4	en	types from moist environments	moist
+GW_05.1_terr_group5	en	types from dry environments	dry
 GW_05.2	en	Groundwater monitoring: environmental pressure 05.2_wet_gw	GW: 05.2_wet_gw
 GW_07.1	en	Groundwater monitoring: environmental pressure 07.1_desal_gw	GW: 07.1_desal_gw
 GW_08.3	en	Groundwater monitoring: environmental pressure 08.3_poll_gw	GW: 08.3_poll_gw
@@ -340,7 +361,19 @@ terr	en	terrestrial	NA
 aq	nl	aquatisch	NA
 ATM	nl	Atmosferisch meetnet	NA
 ATM_03.1	nl	Atmosferisch meetnet: milieudruk 03.1_eutr_atm	ATM: 03.1_eutr_atm
+ATM_03.1_group1	nl	zeer gevoelige niet-bostypes	zeer gevoelig niet-bos
+ATM_03.1_group2	nl	gevoelige niet-bostypes	gevoelig niet-bos
+ATM_03.1_group3	nl	minder tot niet gevoelige niet-bostypes	minder/niet gevoelig niet-bos
+ATM_03.1_group4	nl	zeer gevoelige bostypes	zeer gevoelig bos
+ATM_03.1_group5	nl	gevoelige bostypes	gevoelig bos
+ATM_03.1_group6	nl	minder tot niet gevoelige bostypes	minder/niet gevoelig bos
 ATM_04.1	nl	Atmosferisch meetnet: milieudruk 04.1_verzu_atm	ATM: 04.1_verzu_atm
+ATM_04.1_group1	nl	zeer gevoelige niet-bostypes	zeer gevoelig niet-bos
+ATM_04.1_group2	nl	gevoelige niet-bostypes	gevoelig niet-bos
+ATM_04.1_group3	nl	minder tot niet gevoelige niet-bostypes	minder/niet gevoelig niet-bos
+ATM_04.1_group4	nl	zeer gevoelige bostypes	zeer gevoelig bos
+ATM_04.1_group5	nl	gevoelige bostypes	gevoelig bos
+ATM_04.1_group6	nl	minder tot niet gevoelige bostypes	minder/niet gevoelig bos
 ATM_08.1	nl	Atmosferisch meetnet: milieudruk 08.1_verontr_atm	ATM: 08.1_verontr_atm
 ATM_101	nl	Atmosferisch meetnet: milieudruk 101_klim_droog	ATM: 101_klim_droog
 ATM_102	nl	Atmosferisch meetnet: milieudruk 102_klim_nat	ATM: 102_klim_nat
@@ -425,10 +458,19 @@ FW	nl	Zoete en brakke wateren	NA
 GR	nl	(Half-)natuurlijke graslanden	NA
 GW	nl	Grondwatermeetnet	NA
 GW_03.3	nl	Grondwatermeetnet: milieudruk 03.3_eutr_gw	GW: 03.3_eutr_gw
+GW_03.3_group1	nl	types van oligotroof milieu	oligotroof
+GW_03.3_group2	nl	types van mesotroof milieu	mesotroof
+GW_03.3_group3	nl	types van zwak eutroof milieu	zwak eutroof
+GW_03.3_group4	nl	types van matig eutroof tot eutroof milieu	(matig) eutroof
 GW_04.2	nl	Grondwatermeetnet: milieudruk 04.2_verzu_gw	GW: 04.2_verzu_gw
 GW_05.1_aq	nl	Grondwatermeetnet: milieudruk 05.1_verdro_gw: partim aquatisch	GW: 05.1_verdro_gw: aq
 GW_05.1_caves	nl	Grondwatermeetnet: milieudruk 05.1_verdro_gw: partim grotten	GW: 05.1_verdro_gw: caves
 GW_05.1_terr	nl	Grondwatermeetnet: milieudruk 05.1_verdro_gw: partim terrestrisch	GW: 05.1_verdro_gw: terr
+GW_05.1_terr_group1	nl	types van zeer nat milieu	zeer nat
+GW_05.1_terr_group2	nl	types van nat milieu	nat
+GW_05.1_terr_group3	nl	types van matig nat milieu	matig nat
+GW_05.1_terr_group4	nl	types van vochtig milieu	vochtig
+GW_05.1_terr_group5	nl	types van droog milieu	droog
 GW_05.2	nl	Grondwatermeetnet: milieudruk 05.2_vernat_gw	GW: 05.2_vernat_gw
 GW_07.1	nl	Grondwatermeetnet: milieudruk 07.1_verzoet_gw	GW: 07.1_verzoet_gw
 GW_08.3	nl	Grondwatermeetnet: milieudruk 08.3_verontr_gw	GW: 08.3_verontr_gw

--- a/inst/textdata/namelist.tsv
+++ b/inst/textdata/namelist.tsv
@@ -159,9 +159,9 @@ GR	en	Natural and semi-natural grassland	NA
 GW	en	Groundwater monitoring	NA
 GW_03.3	en	Groundwater monitoring: environmental pressure 03.3_eutr_gw	GW: 03.3_eutr_gw
 GW_04.2	en	Groundwater monitoring: environmental pressure 04.2_acidif_gw	GW: 04.2_acidif_gw
-GW_05.1_aq	en	Groundwater monitoring: environmental pressure 05.1_des_gw: partim aquatic	GW: 05.1_des_gw:  aq
-GW_05.1_caves	en	Groundwater monitoring: environmental pressure 05.1_des_gw: partim caves	GW: 05.1_des_gw:  caves
-GW_05.1_terr	en	Groundwater monitoring: environmental pressure 05.1_des_gw: partim terrestrial	GW: 05.1_des_gw:  terr
+GW_05.1_aq	en	Groundwater monitoring: environmental pressure 05.1_des_gw: partim aquatic	GW: 05.1_des_gw: aq
+GW_05.1_caves	en	Groundwater monitoring: environmental pressure 05.1_des_gw: partim caves	GW: 05.1_des_gw: caves
+GW_05.1_terr	en	Groundwater monitoring: environmental pressure 05.1_des_gw: partim terrestrial	GW: 05.1_des_gw: terr
 GW_05.2	en	Groundwater monitoring: environmental pressure 05.2_wet_gw	GW: 05.2_wet_gw
 GW_07.1	en	Groundwater monitoring: environmental pressure 07.1_desal_gw	GW: 07.1_desal_gw
 GW_08.3	en	Groundwater monitoring: environmental pressure 08.3_poll_gw	GW: 08.3_poll_gw
@@ -426,9 +426,9 @@ GR	nl	(Half-)natuurlijke graslanden	NA
 GW	nl	Grondwatermeetnet	NA
 GW_03.3	nl	Grondwatermeetnet: milieudruk 03.3_eutr_gw	GW: 03.3_eutr_gw
 GW_04.2	nl	Grondwatermeetnet: milieudruk 04.2_verzu_gw	GW: 04.2_verzu_gw
-GW_05.1_aq	nl	Grondwatermeetnet: milieudruk 05.1_verdro_gw: partim aquatisch	GW: 05.1_verdro_gw:  aq
-GW_05.1_caves	nl	Grondwatermeetnet: milieudruk 05.1_verdro_gw: partim grotten	GW: 05.1_verdro_gw:  caves
-GW_05.1_terr	nl	Grondwatermeetnet: milieudruk 05.1_verdro_gw: partim terrestrisch	GW: 05.1_verdro_gw:  terr
+GW_05.1_aq	nl	Grondwatermeetnet: milieudruk 05.1_verdro_gw: partim aquatisch	GW: 05.1_verdro_gw: aq
+GW_05.1_caves	nl	Grondwatermeetnet: milieudruk 05.1_verdro_gw: partim grotten	GW: 05.1_verdro_gw: caves
+GW_05.1_terr	nl	Grondwatermeetnet: milieudruk 05.1_verdro_gw: partim terrestrisch	GW: 05.1_verdro_gw: terr
 GW_05.2	nl	Grondwatermeetnet: milieudruk 05.2_vernat_gw	GW: 05.2_vernat_gw
 GW_07.1	nl	Grondwatermeetnet: milieudruk 07.1_verzoet_gw	GW: 07.1_verzoet_gw
 GW_08.3	nl	Grondwatermeetnet: milieudruk 08.3_verontr_gw	GW: 08.3_verontr_gw

--- a/inst/textdata/namelist.yml
+++ b/inst/textdata/namelist.yml
@@ -6,7 +6,7 @@
   - lang
   - code
   hash: 3345146f5a5902a684bc1b965f00486c82952d94
-  data_hash: b6f363f723085d9bcddfc4a819a4524c89428352
+  data_hash: f19bc1788919448f9244565d264f3a9f3f647e75
 code:
   class: character
 lang:

--- a/inst/textdata/namelist.yml
+++ b/inst/textdata/namelist.yml
@@ -6,7 +6,7 @@
   - lang
   - code
   hash: 3345146f5a5902a684bc1b965f00486c82952d94
-  data_hash: f19bc1788919448f9244565d264f3a9f3f647e75
+  data_hash: fd1e2f7d309d5792583ebd986bbc784129d430f5
 code:
   class: character
 lang:

--- a/inst/textdata/namelist.yml
+++ b/inst/textdata/namelist.yml
@@ -6,7 +6,7 @@
   - lang
   - code
   hash: 3345146f5a5902a684bc1b965f00486c82952d94
-  data_hash: fd1e2f7d309d5792583ebd986bbc784129d430f5
+  data_hash: 587ca7e4489b326586731f36c3d55ba66fb0c7cc
 code:
   class: character
 lang:

--- a/inst/textdata/scheme_types.tsv
+++ b/inst/textdata/scheme_types.tsv
@@ -281,6 +281,7 @@ scheme	type	typegroup
 8	28	NA
 8	30	NA
 8	66	NA
+61	71	NA
 9	2	18
 9	3	16
 9	4	16
@@ -322,7 +323,6 @@ scheme	type	typegroup
 9	68	17
 9	69	17
 9	70	17
-9	71	20
 9	74	19
 9	75	20
 9	77	19

--- a/inst/textdata/scheme_types.yml
+++ b/inst/textdata/scheme_types.yml
@@ -5,8 +5,8 @@
   sorting:
   - scheme
   - type
-  hash: b4dcdfd6d3afdd6965128fe3d03868402c1dc69d
-  data_hash: b2e5c4c5a102e2b6471dbb6f696939293b31934b
+  hash: 2f61c9a6380a10942c134a13068e0088c5407942
+  data_hash: 76f5fa9b25e2e9829a00929c6f5be9e92a0f13f7
 scheme:
   class: factor
   labels:
@@ -18,6 +18,7 @@ scheme:
   - GW_03.3
   - GW_04.2
   - GW_05.1_aq
+  - GW_05.1_caves
   - GW_05.1_terr
   - GW_05.2
   - GW_07.1
@@ -79,6 +80,7 @@ scheme:
   - 6
   - 7
   - 8
+  - 61
   - 9
   - 10
   - 11

--- a/inst/textdata/schemes.tsv
+++ b/inst/textdata/schemes.tsv
@@ -7,6 +7,7 @@ scheme	programme	attribute_1	attribute_2	attribute_3	spatial_restriction	notes	t
 6	1	3	8	NA	NA	NA	1	NA	NA
 7	1	3	11	NA	NA	NA	2	NA	NA
 8	1	3	13	1	NA	NA	1	NA	NA
+61	1	3	13	3	NA	NA	1	NA	NA
 9	1	3	13	2	zones with shallow groundwater (in reach of vegetation)	NA	1	NA	NA
 10	1	3	14	NA	NA	NA	2	NA	NA
 11	1	3	21	NA	NA	NA	2	NA	NA

--- a/inst/textdata/schemes.yml
+++ b/inst/textdata/schemes.yml
@@ -5,8 +5,8 @@
   sorting:
   - programme
   - scheme
-  hash: dcdec23718d9919581a0baa5a22d12dc209dfaed
-  data_hash: 69a0183f0f166be369ffe03eb669cf9a002c2100
+  hash: bed5a9d0597f17537f28793acd131dcf0ff3be42
+  data_hash: 19a86a644852da61b20435a21d9784f509bcbe62
 scheme:
   class: factor
   labels:
@@ -18,6 +18,7 @@ scheme:
   - GW_03.3
   - GW_04.2
   - GW_05.1_aq
+  - GW_05.1_caves
   - GW_05.1_terr
   - GW_05.2
   - GW_07.1
@@ -79,6 +80,7 @@ scheme:
   - 6
   - 7
   - 8
+  - 61
   - 9
   - 10
   - 11
@@ -287,9 +289,11 @@ attribute_3:
   class: factor
   labels:
   - aq
+  - caves
   - terr
   index:
   - 1
+  - 3
   - 2
   ordered: no
 spatial_restriction:

--- a/misc/generate_textdata/30_schemes_and_scheme_types.Rmd
+++ b/misc/generate_textdata/30_schemes_and_scheme_types.Rmd
@@ -339,7 +339,7 @@ read_vc(schemes_path) %>%
                              name_3,
                              ifelse(is.na(attribute_3),
                                  "",
-                                 str_c(":  ",
+                                 str_c(": ",
                                        attribute_3)
                                  )
                              )

--- a/misc/generate_textdata/30_schemes_and_scheme_types.Rmd
+++ b/misc/generate_textdata/30_schemes_and_scheme_types.Rmd
@@ -350,6 +350,59 @@ read_vc(schemes_path) %>%
     write_vc(namelist_path)
 ```
 
+Appending names and shortnames for typegroups of MNE schemes:
+
+```{r}
+tribble(~nr, ~lang, ~name, ~shortname,
+        1, "en", "very sensitive non-forest types", "very sensitive non-forest",
+        1, "nl", "zeer gevoelige niet-bostypes", "zeer gevoelig niet-bos",
+        2, "en", "sensitive non-forest types", "sensitive non-forest",
+        2, "nl", "gevoelige niet-bostypes", "gevoelig niet-bos",
+        3, "en", "less to not sensitive non-forest types", "less/not sensitive non-forest",
+        3, "nl", "minder tot niet gevoelige niet-bostypes", "minder/niet gevoelig niet-bos",
+        4, "en", "very sensitive forest types", "very sensitive forest",
+        4, "nl", "zeer gevoelige bostypes", "zeer gevoelig bos",
+        5, "en", "sensitive forest types", "sensitive forest",
+        5, "nl", "gevoelige bostypes", "gevoelig bos",
+        6, "en", "less to not sensitive forest types", "less/not sensitive forest",
+        6, "nl", "minder tot niet gevoelige bostypes", "minder/niet gevoelig bos"
+        ) %>% 
+  crossing(prefix = c("ATM_03.1_group", "ATM_04.1_group")) %>% 
+  mutate(code = str_c(prefix, nr)) %>% 
+  select(code, lang, name, shortname) %>% 
+  bind_rows(
+    tribble(~code, ~lang, ~name, ~shortname,
+        1, "en", "types from oligotrophic environments", "oligotrophic",
+        1, "nl", "types van oligotroof milieu", "oligotroof",
+        2, "en", "types from mesotrophic environments", "mesotrophic",
+        2, "nl", "types van mesotroof milieu", "mesotroof",
+        3, "en", "types from weakly eutrophic environments", "weakly eutrophic",
+        3, "nl", "types van zwak eutroof milieu", "zwak eutroof",
+        4, "en", "types from moderately eutrophic to eutrophic environments", "(moderately) eutrophic",
+        4, "nl", "types van matig eutroof tot eutroof milieu", "(matig) eutroof"
+        ) %>% 
+      mutate(code = str_c("GW_03.3_group", code))
+  ) %>% 
+  bind_rows(
+        tribble(~code, ~lang, ~name, ~shortname,
+        1, "en", "types from very wet environments", "very wet",
+        1, "nl", "types van zeer nat milieu", "zeer nat",
+        2, "en", "types from wet environments", "wet",
+        2, "nl", "types van nat milieu", "nat",
+        3, "en", "types from moderately wet environments", "moderately wet",
+        3, "nl", "types van matig nat milieu", "matig nat",
+        4, "en", "types from moist environments", "moist",
+        4, "nl", "types van vochtig milieu", "vochtig",
+        5, "en", "types from dry environments", "dry",
+        5, "nl", "types van droog milieu", "droog"
+        ) %>% 
+      mutate(code = str_c("GW_05.1_terr_group", code))
+  ) %>% 
+  bind_rows(read_vc(namelist_path),
+              .) %>% 
+  write_vc(namelist_path)
+```
+
 
 
 ## Appending records for the monitoring programme for biotic habitat quality (MHQ)

--- a/misc/generate_textdata/30_schemes_and_scheme_types.Rmd
+++ b/misc/generate_textdata/30_schemes_and_scheme_types.Rmd
@@ -70,7 +70,10 @@ schemes_schemetypes <-
         attribute_3 = ifelse(attribute_1 == "GW" & attribute_2 == "ep_05.1",
                              ifelse(attribute_3 == "Oppervlaktewater",
                                     "aq",
-                                    "terr"),
+                                    ifelse(type == "8310",
+                                           "caves",
+                                           "terr")
+                                    ),
                              NA) %>% 
                       factor,
         scheme = str_c(attribute_1, 
@@ -188,7 +191,9 @@ typegroups <-
                 verbose = FALSE) %>% 
         filter(!Type %in% 
                    (schemes_schemetypes %>% 
-                        filter(scheme == "GW_05.1_aq") %>% 
+                        filter(scheme %in% 
+                                 c("GW_05.1_aq", 
+                                   "GW_05.1_caves")) %>% 
                         .$type)
                ) %>% 
         mutate(scheme = "GW_05.1_terr") %>% 
@@ -270,9 +275,11 @@ cbind(code = c("ATM", "SOIL", "GW", "SURF", "INUN"),
                    "Inundatiemeetnet")) %>% 
     rbind(matrix(c("aq", "en", "aquatic",
                    "terr", "en", "terrestrial",
+                   "caves", "en", "caves",
                    "aq", "nl", "aquatisch",
-                   "terr", "nl", "terrestrisch"),
-                 nrow = 4,
+                   "terr", "nl", "terrestrisch",
+                   "caves", "nl", "grotten"),
+                 ncol = 3,
                  byrow = TRUE)) %>% 
     rbind(matrix(c("focal", "en", "Focal scheme",
                    "secondary", "en", "Secondary scheme",


### PR DESCRIPTION
- regarding _Groundwater monitoring: environmental pressure 05.1_des_gw_, type 8310 has been put in its own, separate scheme because it cannot have the same environmental variable as the other types of the terrestrial scheme. We end up with three schemes here: terrestrial, aquatic and caves...
- for all distinguished typegroups (i.e. grouping of types within a scheme), English & Dutch names and shortnames have been added. (More languages can be accommodated.) With credits to @w-jan for proposing names of the _GW_05.1_terr_ typegroups.

You can explore and use this after installing the package (see [README](https://github.com/inbo/n2khab/blob/master/README.md) for the `install_github()` command, but add the `ref = "typegroups"` argument):

```r
schemes_en <- read_schemes()
schemes_nl <- read_schemes(lang = "nl")
scheme_types_en <- read_scheme_types()
scheme_types_nl <- read_scheme_types(lang = "nl")

# inspect the different schemes with and without typegroups:
scheme_types_en %>%
  select(-type) %>% 
  distinct %>% 
  arrange(scheme, typegroup) %>% 
  View
# etcetera
```