### PR TITLE
expand_types(): adapt to updated tidyr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,7 @@ Imports:
     stats,
     stringr,
     tibble,
-    tidyr,
+    tidyr (>= 1.0.0),
     utils,
     withr
 Encoding: UTF-8

--- a/R/datawrangling.R
+++ b/R/datawrangling.R
@@ -136,14 +136,14 @@ expand_types <- function(x,
         } else {
 
     x %>%
-        nest() %>%
+        nest(data = -!!(group_vars(x))) %>%
         mutate(newdata = map(.data$data,
                              expand_types_plain,
                              type_var = type_var,
                              strict = strict)
         ) %>%
         select(-.data$data) %>%
-        unnest %>%
+        unnest(cols = .data$newdata) %>%
         group_by_at(x %>% group_vars()) %>%
         select(colnames(x))
 


### PR DESCRIPTION
Since `tidyr` version `1.0.0`, `nest()` and `unnest()` throw warnings with the current implementation, in part depending on the type of data frame provided as `x` (grouped vs. not grouped).

This commit adapts to the needs of the new `nest()` and `unnest()`. Version `1.0.0` of `tidyr` is now required.