### PR TITLE
read_habitatmap_terr(): add option to exclude aquatic patches

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: n2khab
 Title: Providing preprocessed reference data for Flemish Natura 2000 habitat analyses
-Version: 0.0.3.9034
+Version: 0.0.3.9035
 Authors@R: c(
     person("Floris", "Vanderhaeghe", email = "floris.vanderhaeghe@inbo.be", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6378-6229")), 
     person("Toon", "Westra", email = "toon.westra@inbo.be", role = c("aut"), comment = c(ORCID = "0000-0003-2478-9459")), 

--- a/R/read_habitatdata.R
+++ b/R/read_habitatdata.R
@@ -452,6 +452,18 @@ read_habitatmap <-
 #' \href{https://github.com/inbo/n2khab-preprocessing}{n2khab-preprocessing}
 #' repository.
 #'
+#' @param keep_aq_patches Logical; \code{TRUE} by default.
+#' The data source \code{habitatmap_terr} aims at delineating all
+#' polygons with at least one (semi-)terrestrial type (i.e. patch).
+#' For those polygons, it returns all known habitat types and RIBs as patches.
+#' Hence, in several cases polygons do occur with a combination of terrestrial
+#' and aquatic patches.
+#' Setting \code{keep_aq_patches = FALSE} is convenient for use cases where one
+#' only wants to look at the (semi-)terrestrial patches: this setting will
+#' discard all aquatic patches in 'mixed' aquatic/terrestrial polygons.
+#' The aquatic types are defined as those with hydrological class \code{"HC3"}
+#' (see \code{tag_2}) in the \code{\link{types}} data source.
+#'
 #' @inheritParams read_habitatmap_stdized
 #'
 #' @return
@@ -493,20 +505,33 @@ read_habitatmap <-
 #' # In all other cases, this example won't work but at least you can
 #' # consider what to do.
 #'
-#' r <- read_habitatmap_terr()
-#' r_polygons <- r$habitatmap_terr_polygons
-#' r_patches <- r$habitatmap_terr_patches
+#' habmap_terr <- read_habitatmap_terr()
+#' habmap_terr$habitatmap_terr_polygons
+#' habmap_terr$habitatmap_terr_patches
+#'
+#' habmap_terr_noaq <- read_habitatmap_terr(keep_aq_patches = FALSE)
+#' habmap_terr_noaq$habitatmap_terr_polygons
+#' habmap_terr_noaq$habitatmap_terr_patches
 #' }
 #'
 #' @export
+#' @importFrom assertthat
+#' assert_that
+#' is.flag
 #' @importFrom sf
 #' read_sf
 #' st_crs<-
 #' @importFrom rlang .data
-#' @importFrom dplyr %>% mutate
+#' @importFrom dplyr
+#' %>%
+#' mutate
+#' filter
 read_habitatmap_terr <-
     function(path = fileman_up("n2khab_data"),
-             file = "20_processed/habitatmap_terr/habitatmap_terr.gpkg"){
+             file = "20_processed/habitatmap_terr/habitatmap_terr.gpkg",
+             keep_aq_patches = TRUE){
+
+        assert_that(is.flag(keep_aq_patches))
 
         habmap_terr_polygons <- read_sf(file.path(path, file),
                                    "habitatmap_terr_polygons")
@@ -533,6 +558,22 @@ read_habitatmap_terr <-
                     ),
                     source = factor(.data$source)
             )
+
+        if (!keep_aq_patches) {
+            habmap_terr_patches <-
+                habmap_terr_patches %>%
+                filter(!(.data$type %in% (types %>%
+                                          filter(.data$tag_2 == "HC3") %>%
+                                          .$type)
+                         ))
+            # The below step is unneeded (and takes several seconds),
+            # because polygons with _no_ terrestrial patches were already
+            # excluded in the data source.
+            #
+            # habmap_terr_polygons %>%
+            #     dplyr::semi_join(habmap_terr_patches,
+            #                      by = "polygon_id")
+        }
 
         result <- list(habitatmap_terr_polygons = habmap_terr_polygons,
                        habitatmap_terr_patches = habmap_terr_patches)

--- a/R/read_habitatdata.R
+++ b/R/read_habitatdata.R
@@ -422,9 +422,15 @@ read_habitatmap <-
 #' \itemize{
 #' \item{it excludes all polygons
 #' that are most probably aquatic habitat or RIB.
-#' Also \code{1130} is excluded.
-#' In the process, a distinction is also made between \code{2190_a} and
-#' \code{2190_overig};}
+#' These are the polygons for which
+#' \strong{all} habitat or RIB patches are aquatic.
+#' In the process, a distinction was also made between \code{2190_a} and
+#' \code{2190_overig}.
+#' There is no exclusion of aquatic patches when these coexist with
+#' terrestrial patches in the same polygon.
+#' The aquatic types are the types for which \code{tag_2 == "HC3"}
+#' in the \code{\link{types}} data source (\code{tag_2} is the hydrological
+#' class; cf. the output of \code{\link[=read_types]{read_types()}});}
 #' \item{it excludes patches which most probably are \emph{no}
 #' habitat or RIB at all.
 #' Those are the patches where \code{code_orig} contains \code{"bos"} or is
@@ -457,12 +463,13 @@ read_habitatmap <-
 #' polygons with at least one (semi-)terrestrial type (i.e. patch).
 #' For those polygons, it returns all known habitat types and RIBs as patches.
 #' Hence, in several cases polygons do occur with a combination of terrestrial
-#' and aquatic patches.
+#' and aquatic patches (see \emph{Details} for a definition of 'aquatic').
 #' Setting \code{keep_aq_patches = FALSE} is convenient for use cases where one
 #' only wants to look at the (semi-)terrestrial patches: this setting will
 #' discard all aquatic patches in 'mixed' aquatic/terrestrial polygons.
-#' The aquatic types are defined as those with hydrological class \code{"HC3"}
-#' (see \code{tag_2}) in the \code{\link{types}} data source.
+#' As each polygon always has at least one (semi-)terrestrial type,
+#' this will not affect the number of polygons returned,
+#' only the number of patches.
 #'
 #' @inheritParams read_habitatmap_stdized
 #'

--- a/man/read_habitatmap_terr.Rd
+++ b/man/read_habitatmap_terr.Rd
@@ -27,12 +27,13 @@ The data source \code{habitatmap_terr} aims at delineating all
 polygons with at least one (semi-)terrestrial type (i.e. patch).
 For those polygons, it returns all known habitat types and RIBs as patches.
 Hence, in several cases polygons do occur with a combination of terrestrial
-and aquatic patches.
+and aquatic patches (see \emph{Details} for a definition of 'aquatic').
 Setting \code{keep_aq_patches = FALSE} is convenient for use cases where one
 only wants to look at the (semi-)terrestrial patches: this setting will
 discard all aquatic patches in 'mixed' aquatic/terrestrial polygons.
-The aquatic types are defined as those with hydrological class \code{"HC3"}
-(see \code{tag_2}) in the \code{\link{types}} data source.}
+As each polygon always has at least one (semi-)terrestrial type,
+this will not affect the number of polygons returned,
+only the number of patches.}
 }
 \value{
 A list of two objects:
@@ -76,9 +77,15 @@ follows:
 \itemize{
 \item{it excludes all polygons
 that are most probably aquatic habitat or RIB.
-Also \code{1130} is excluded.
-In the process, a distinction is also made between \code{2190_a} and
-\code{2190_overig};}
+These are the polygons for which
+\strong{all} habitat or RIB patches are aquatic.
+In the process, a distinction was also made between \code{2190_a} and
+\code{2190_overig}.
+There is no exclusion of aquatic patches when these coexist with
+terrestrial patches in the same polygon.
+The aquatic types are the types for which \code{tag_2 == "HC3"}
+in the \code{\link{types}} data source (\code{tag_2} is the hydrological
+class; cf. the output of \code{\link[=read_types]{read_types()}});}
 \item{it excludes patches which most probably are \emph{no}
 habitat or RIB at all.
 Those are the patches where \code{code_orig} contains \code{"bos"} or is

--- a/man/read_habitatmap_terr.Rd
+++ b/man/read_habitatmap_terr.Rd
@@ -6,7 +6,8 @@
 objects}
 \usage{
 read_habitatmap_terr(path = fileman_up("n2khab_data"),
-  file = "20_processed/habitatmap_terr/habitatmap_terr.gpkg")
+  file = "20_processed/habitatmap_terr/habitatmap_terr.gpkg",
+  keep_aq_patches = TRUE)
 }
 \arguments{
 \item{path}{Location of the file.
@@ -20,6 +21,18 @@ starting from the working directory.}
 May include a path prefix.
 The default follows the data management advice in the
 \href{../doc/v020_datastorage.html}{vignette} on data storage.}
+
+\item{keep_aq_patches}{Logical; \code{TRUE} by default.
+The data source \code{habitatmap_terr} aims at delineating all
+polygons with at least one (semi-)terrestrial type (i.e. patch).
+For those polygons, it returns all known habitat types and RIBs as patches.
+Hence, in several cases polygons do occur with a combination of terrestrial
+and aquatic patches.
+Setting \code{keep_aq_patches = FALSE} is convenient for use cases where one
+only wants to look at the (semi-)terrestrial patches: this setting will
+discard all aquatic patches in 'mixed' aquatic/terrestrial polygons.
+The aquatic types are defined as those with hydrological class \code{"HC3"}
+(see \code{tag_2}) in the \code{\link{types}} data source.}
 }
 \value{
 A list of two objects:
@@ -101,9 +114,13 @@ repository.
 # In all other cases, this example won't work but at least you can
 # consider what to do.
 
-r <- read_habitatmap_terr()
-r_polygons <- r$habitatmap_terr_polygons
-r_patches <- r$habitatmap_terr_patches
+habmap_terr <- read_habitatmap_terr()
+habmap_terr$habitatmap_terr_polygons
+habmap_terr$habitatmap_terr_patches
+
+habmap_terr_noaq <- read_habitatmap_terr(keep_aq_patches = FALSE)
+habmap_terr_noaq$habitatmap_terr_polygons
+habmap_terr_noaq$habitatmap_terr_patches
 }
 
 }


### PR DESCRIPTION
Copied from the documentation of the newly added argument `keep_aq_patches`:

> `keep_aq_patches`       Logical; `TRUE` by default. The data source `habitatmap_terr` aims at delineating all polygons with at least one (semi-)terrestrial type (i.e. patch). For those polygons, it returns all known habitat types and RIBs as patches. Hence, in several cases polygons do occur with a combination of terrestrial and aquatic patches. Setting `keep_aq_patches = FALSE` is convenient for use cases where one only wants to look at the (semi-)terrestrial patches: this setting will discard all aquatic patches in 'mixed' aquatic/terrestrial polygons. The aquatic types are defined as those with hydrological class `"HC3"` (see `tag_2`) in the `types` data source.