### PR TITLE
Update the types data source + read_types()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: n2khab
 Title: Providing preprocessed reference data for Flemish Natura 2000 habitat analyses
-Version: 0.0.3.9043
+Version: 0.0.3.9044
 Authors@R: c(
     person("Floris", "Vanderhaeghe", email = "floris.vanderhaeghe@inbo.be", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6378-6229")), 
     person("Toon", "Westra", email = "toon.westra@inbo.be", role = c("aut"), comment = c(ORCID = "0000-0003-2478-9459")), 

--- a/R/read_textdata.R
+++ b/R/read_textdata.R
@@ -182,7 +182,7 @@ namelist_factor <-
 #' A tibble is a dataframe that makes working in the tidyverse a little
 #' \href{https://r4ds.had.co.nz/tibbles.html}{easier}.
 #' By default, the data version delivered with the package is used and English
-#' names (\code{lang = "en"}) are returned for types, typeclasses and tags.
+#' names (\code{lang = "en"}) are returned for types, attributes and tags.
 #'
 #' @param path Location of the data sources \code{types} and \code{namelist}.
 #' The default is to use the location of the data sources as delivered by
@@ -199,9 +199,8 @@ namelist_factor <-
 #'
 #' @return
 #' The \code{types} dataframe as a \code{\link[tibble:tbl_df-class]{tibble}},
-#' with names & shortnames added for types, typeclasses and tags
+#' with names & shortnames added for types, attributes and tags
 #' according to the \code{lang} argument.
-#' The tibble has 108 rows and 16 variables.
 #' See \code{\link{types}} for documentation of the data-source's contents.
 #' See \code{\link{namelist}} for the link between codes or other identifiers
 #' and the corresponding names (and shortnames).
@@ -210,8 +209,13 @@ namelist_factor <-
 #' \itemize{
 #'   \item \code{type_name}
 #'   \item \code{type_shortname}
-#'   \item \code{typeclass_name}: a factor with the level order
-#'   according to that of \code{typeclass}.
+#'   \item \code{typeclass_name}
+#'   \item \code{hydr_class_name}
+#'   \item \code{hydr_class_shortname}
+#'   \item \code{groundw_dep_name}
+#'   \item \code{groundw_dep_shortname}
+#'   \item \code{flood_dep_name}
+#'   \item \code{flood_dep_shortname}
 #'   \item \code{tag_1_name}
 #'   \item \code{tag_1_shortname}
 #'   \item \code{tag_2_name}
@@ -219,6 +223,9 @@ namelist_factor <-
 #'   \item \code{tag_3_name}
 #'   \item \code{tag_3_shortname}
 #' }
+#' Except for the tags, the names and shortnames are factors with their level
+#' order according to that of the corresponding attribute.
+
 #'
 #' @section Recommended usage:
 #'
@@ -282,7 +289,7 @@ read_types <-
         types_base <-
             read_vc(file = file, root = path)
 
-        suppressWarnings({
+        suppressMessages(suppressWarnings({
         type_levels <-
             tibble(codelevel = types_base$type %>% levels) %>%
             left_join(namelist,
@@ -290,7 +297,7 @@ read_types <-
             rename(namelevel = .data$name,
                    shortnamelevel = .data$shortname)
 
-                typeclass_levels <-
+        typeclass_levels <-
             tibble(codelevel = types_base$typeclass %>% levels) %>%
             left_join(namelist %>% select(-.data$shortname),
                        by = c("codelevel" = "code")) %>%
@@ -314,8 +321,32 @@ read_types <-
                    typeclass_name =
                        .data$typeclass %>%
                        mapvalues(from = typeclass_levels$codelevel,
-                                 to = typeclass_levels$namelevel)
-                  ) %>%
+                                 to = typeclass_levels$namelevel),
+                   hydr_class_name =
+                       .data$hydr_class %>%
+                       mapvalues(from = namelist$code,
+                                 to = namelist$name),
+                   hydr_class_shortname =
+                       .data$hydr_class %>%
+                       mapvalues(from = namelist$code,
+                                 to = namelist$shortname),
+                   groundw_dep_name =
+                       .data$groundw_dep %>%
+                       mapvalues(from = namelist$code,
+                                 to = namelist$name),
+                   groundw_dep_shortname =
+                       .data$groundw_dep %>%
+                       mapvalues(from = namelist$code,
+                                 to = namelist$shortname),
+                   flood_dep_name =
+                       .data$flood_dep %>%
+                       mapvalues(from = namelist$code,
+                                 to = namelist$name),
+                   flood_dep_shortname =
+                       .data$flood_dep %>%
+                       mapvalues(from = namelist$code,
+                                 to = namelist$shortname)
+            ) %>%
             left_join(namelist,
                       by = c("tag_1" = "code")) %>%
             rename(tag_1_name = .data$name,
@@ -328,13 +359,16 @@ read_types <-
                       by = c("tag_3" = "code")) %>%
             rename(tag_3_name = .data$name,
                    tag_3_shortname = .data$shortname) %>%
-            select(1:3, 8:9,
-                   4, 10,
-                   5, 11:12,
-                   6, 13:14,
-                   7, 15:16) %>%
+            select(1:3, 11:12,
+                   4, 13,
+                   5, 14:15,
+                   6, 16:17,
+                   7, 18:19,
+                   8, 20:21,
+                   9, 22:23,
+                   10, 24:25) %>%
             as_tibble
-        })
+        }))
     }
 
 

--- a/R/textdata.R
+++ b/R/textdata.R
@@ -50,12 +50,13 @@ NULL
 #' with several attributes.
 #' A 'type' refers to either a (main) habitat type, a
 #' habitat subtype or a regionally important biotope (RIB).
-#' The codes of types, typeclasses and tags are explained in the
+#' The codes of types, typeclasses and further attributes and tags are
+#' explained in the
 #' data source \code{\link{namelist}} (which can accommodate multiple
 #' languages).
 #'
 #' @format A vc-formatted data source. As such, it corresponds to
-#' a dataframe with 7 variables:
+#' a dataframe with several variables:
 #' \describe{
 #'   \item{type}{Code of the type, as a factor.
 #'   This is the ID for use in diverse workflows and datasets.
@@ -72,12 +73,24 @@ NULL
 #'   \item{typeclass}{A code explained by \code{\link{namelist}},
 #'   corresponding to the typeclass.
 #'   Is a factor.}
+#'   \item{hydr_class}{A code explained by \code{\link{namelist}},
+#'   corresponding to the hydrological class.
+#'   Is a factor.}
+#'   \item{ground_dep}{A code explained by \code{\link{namelist}},
+#'   corresponding to the groundwater dependency category.
+#'   Is a factor.}
+#'   \item{flood_dep}{A code explained by \code{\link{namelist}},
+#'   corresponding to the flood dependency category.
+#'   Is a factor.
+#'   Note that flood dependency is only defined for (semi-)terrestrial types,
+#'   hence for aquatic types (hydrological class \code{HC3})
+#'   it is \code{NA}.}
 #'   \item{tag_1}{Optional tag, e.g. a categorization ID explained
 #'   by \code{\link{namelist}}.
-#'   Currently used to indicate subcategories within a few typeclasses.}
+#'   Currently used to indicate subcategories within a few typeclasses,
+#'   or to differentiate between lotic and lentic aquatic types.}
 #'   \item{tag_2}{Optional tag, e.g. a categorization ID explained
-#'   by \code{\link{namelist}}.
-#'   Currently used to indicate the hydrological class.}
+#'   by \code{\link{namelist}}.}
 #'   \item{tag_3}{Optional tag, e.g. a categorization ID explained
 #'   by \code{\link{namelist}}.} }
 #'
@@ -95,8 +108,24 @@ NULL
 #'
 #' @source
 #'
-#' \href{https://docs.google.com/spreadsheets/d/1dK0S1Tt3RlVEh4WrNF5N_-hn0OXiTUVOvsL2JRhSl78}{This googlesheet}.
+#' Most information comes from
+#' \href{https://docs.google.com/spreadsheets/d/1dK0S1Tt3RlVEh4WrNF5N_-hn0OXiTUVOvsL2JRhSl78}{this googlesheet}.
 #' Currently, the googlesheet and the data source are both kept up-to-date.
+#' However only the 'types' data source is under version control.
+#'
+#' The source for the hydrological class attribute is a vc-formatted file
+#' stored in the package source code.
+#' It is read by the 'generate_textdata' bookdown project which generates the
+#' 'types' data source.
+#' The referred vc-formatted file was derived from a yet unpublished database
+#' on the interrelations
+#' between types, hydrological classes, environmental compartments and their
+#' characteristics, and environmental pressures.
+#'
+#' The source for the groundwater and flood dependency attributes is
+#' \href{https://docs.google.com/spreadsheets/d/1bhXgamK28K--MSWF7goKNOWtWPEI149_QCpU-3V_k_E}{this googlesheet}.
+#' Currently, the googlesheet and the data source are both kept up-to-date.
+#' However only the 'types' data source is under version control.
 #'
 #' @seealso \code{\link{read_types}}
 #'

--- a/inst/textdata/namelist.tsv
+++ b/inst/textdata/namelist.tsv
@@ -115,8 +115,14 @@ CT	en	Calcareous type	NA
 DI	en	Dike inward	NA
 DIO	en	Dike in-/outward	NA
 DO	en	Dike outward	NA
+FD0	en	flood independent	flood independent
+FD1	en	flood dependent on a part of the locations	locally flood dependent
+FD2	en	flood dependent on (almost) all locations	(almost) everywhere flood dependent
 FS	en	Forest and scrub	NA
 FW	en	Fresh and brackish water	NA
+GD0	en	groundwater independent	groundwater independent
+GD1	en	groundwater dependent on a part of the locations	locally groundwater dependent
+GD2	en	groundwater dependent on (almost) all locations	(almost) everywhere groundwater dependent
 GR	en	Natural and semi-natural grassland	NA
 GW	en	Groundwater monitoring	NA
 GW_03.3	en	Groundwater monitoring: environmental pressure 03.3_eutr_gw	GW: 03.3_eutr_gw
@@ -391,8 +397,14 @@ CT	nl	Kalkrijkere (sub)types	NA
 DI	nl	Binnendijks	NA
 DIO	nl	Binnen- en buitendijks	NA
 DO	nl	Buitendijks	NA
+FD0	nl	niet overstromingsafhankelijk	niet overstromingsafhankelijk
+FD1	nl	overstromingsafhankelijk op een deel van de locaties	plaatselijk overstromingsafhankelijk
+FD2	nl	overstromingsafhankelijk op (bijna) alle locaties	(bijna) overal overstromingsafhankelijk
 FS	nl	Bossen en struwelen	NA
 FW	nl	Zoete en brakke wateren	NA
+GD0	nl	niet grondwaterafhankelijk	niet grondwaterafhankelijk
+GD1	nl	grondwaterafhankelijk op een deel van de locaties	plaatselijk grondwaterafhankelijk
+GD2	nl	grondwaterafhankelijk op (bijna) alle locaties	(bijna) overal grondwaterafhankelijk
 GR	nl	(Half-)natuurlijke graslanden	NA
 GW	nl	Grondwatermeetnet	NA
 GW_03.3	nl	Grondwatermeetnet: milieudruk 03.3_eutr_gw	GW: 03.3_eutr_gw

--- a/inst/textdata/namelist.yml
+++ b/inst/textdata/namelist.yml
@@ -6,7 +6,7 @@
   - lang
   - code
   hash: 3345146f5a5902a684bc1b965f00486c82952d94
-  data_hash: 10cfd11d24cc0612ee5938e5071f50f2834d042a
+  data_hash: ceed6ddb1aa60cbbbb73883108b6e54d5ae0dae3
 code:
   class: character
 lang:

--- a/inst/textdata/types.tsv
+++ b/inst/textdata/types.tsv
@@ -1,112 +1,112 @@
-type	typelevel	main_type	typeclass	hydr_class	tag_1	tag_2	tag_3
-1130	main_type	1130	CH	HC3	DO	NA	NA
-1140	main_type	1140	CH	HC2	DO	NA	NA
-1310	main_type	1310	CH	HC2	DIO	NA	NA
-1310_pol	subtype	1310	CH	HC2	DI	NA	NA
-1310_zk	subtype	1310	CH	HC2	DO	NA	NA
-1310_zv	subtype	1310	CH	HC2	DO	NA	NA
-1320	main_type	1320	CH	HC2	DO	NA	NA
-1330	main_type	1330	CH	HC2	DIO	NA	NA
-1330_da	subtype	1330	CH	HC2	DO	NA	NA
-1330_hpr	subtype	1330	CH	HC2	DI	NA	NA
-2110	main_type	2110	CD	HC12	NA	NA	NA
-2120	main_type	2120	CD	HC1	NA	NA	NA
-2130	main_type	2130	CD	HC12	NA	NA	NA
-2130_had	subtype	2130	CD	HC12	NA	NA	NA
-2130_hd	subtype	2130	CD	HC12	NA	NA	NA
-2150	main_type	2150	CD	HC1	NA	NA	NA
-2160	main_type	2160	CD	HC12	NA	NA	NA
-2170	main_type	2170	CD	HC2	NA	NA	NA
-2180	main_type	2180	CD	HC12	NA	NA	NA
-2190	main_type	2190	CD	HC23	NA	NA	NA
-2190_a	subtype	2190	CD	HC3	SW	NA	NA
-2190_mp	subtype	2190	CD	HC2	NA	NA	NA
-2190_overig	subtype	2190	CD	HC2	NA	NA	NA
-2310	main_type	2310	ID	HC1	NA	NA	NA
-2330	main_type	2330	ID	HC1	NA	NA	NA
-2330_bu	subtype	2330	ID	HC1	NA	NA	NA
-2330_dw	subtype	2330	ID	HC1	NA	NA	NA
-3110	main_type	3110	FW	HC3	SW	NA	NA
-3130	main_type	3130	FW	HC3	SW	NA	NA
-3130_aom	subtype	3130	FW	HC3	SW	NA	NA
-3130_na	subtype	3130	FW	HC3	SW	NA	NA
-3140	main_type	3140	FW	HC3	SW	NA	NA
-3150	main_type	3150	FW	HC3	SW	NA	NA
-3160	main_type	3160	FW	HC3	SW	NA	NA
-3260	main_type	3260	FW	HC3	RW	NA	NA
-3270	main_type	3270	FW	HC2	NA	NA	NA
-rbbah	main_type	rbbah	FW	HC3	SW	NA	NA
-4010	main_type	4010	HS	HC2	NA	NA	NA
-4030	main_type	4030	HS	HC1	NA	NA	NA
-rbbsg	main_type	rbbsg	HS	HC1	NA	NA	NA
-rbbsm	main_type	rbbsm	HS	HC2	NA	NA	NA
-5130	main_type	5130	SS	HC1	NA	NA	NA
-5130_hei	subtype	5130	SS	HC1	NA	NA	NA
-5130_kalk	subtype	5130	SS	HC1	CT	NA	NA
-6120	main_type	6120	GR	HC2	CT	NA	NA
-6210	main_type	6210	GR	HC1	CT	NA	NA
-6210_hk	subtype	6210	GR	HC1	CT	NA	NA
-6210_sk	subtype	6210	GR	HC1	CT	NA	NA
-6230	main_type	6230	GR	HC12	NA	NA	NA
-6230_ha	subtype	6230	GR	HC1	NA	NA	NA
-6230_hmo	subtype	6230	GR	HC2	NA	NA	NA
-6230_hn	subtype	6230	GR	HC1	NA	NA	NA
-6230_hnk	subtype	6230	GR	HC1	CT	NA	NA
-6410	main_type	6410	GR	HC2	NA	NA	NA
-6410_mo	subtype	6410	GR	HC2	NA	NA	NA
-6410_ve	subtype	6410	GR	HC2	NA	NA	NA
-6430	main_type	6430	GR	HC12	NA	NA	NA
-6430_bz	subtype	6430	GR	HC12	NA	NA	NA
-6430_hf	subtype	6430	GR	HC2	NA	NA	NA
-6430_hw	subtype	6430	GR	HC2	NA	NA	NA
-6430_mr	subtype	6430	GR	HC2	NA	NA	NA
-6510	main_type	6510	GR	HC12	NA	NA	NA
-6510_hu	subtype	6510	GR	HC12	NA	NA	NA
-6510_hua	subtype	6510	GR	HC2	NA	NA	NA
-6510_huk	subtype	6510	GR	HC1	CT	NA	NA
-6510_hus	subtype	6510	GR	HC2	NA	NA	NA
-rbbha	main_type	rbbha	GR	HC1	NA	NA	NA
-rbbhc	main_type	rbbhc	GR	HC2	NA	NA	NA
-rbbhf	main_type	rbbhf	GR	HC2	NA	NA	NA
-rbbhfl	main_type	rbbhfl	GR	HC2	NA	NA	NA
-rbbkam	main_type	rbbkam	GR	HC12	NA	NA	NA
-rbbkam+	subtype	rbbkam	GR	HC12	NA	NA	NA
-rbbvos	main_type	rbbvos	GR	HC2	NA	NA	NA
-rbbvos+	subtype	rbbvos	GR	HC2	NA	NA	NA
-rbbzil	main_type	rbbzil	GR	HC2	NA	NA	NA
-rbbzil+	subtype	rbbzil	GR	HC2	NA	NA	NA
-7110	main_type	7110	BMF	HC2	NA	NA	NA
-7140	main_type	7140	BMF	HC2	NA	NA	NA
-7140_base	subtype	7140	BMF	HC2	NA	NA	NA
-7140_meso	subtype	7140	BMF	HC2	NA	NA	NA
-7140_mrd	subtype	7140	BMF	HC2	NA	NA	NA
-7140_oli	subtype	7140	BMF	HC2	NA	NA	NA
-7150	main_type	7150	BMF	HC2	NA	NA	NA
-7210	main_type	7210	BMF	HC2	NA	NA	NA
-7220	main_type	7220	BMF	HC3	RW	NA	NA
-7230	main_type	7230	BMF	HC2	NA	NA	NA
-rbbmc	main_type	rbbmc	BMF	HC2	NA	NA	NA
-rbbmr	main_type	rbbmr	BMF	HC2	NA	NA	NA
-rbbms	main_type	rbbms	BMF	HC2	NA	NA	NA
-8310	main_type	8310	RC	HC12	NA	NA	NA
-9110	main_type	9110	FS	HC1	NA	NA	NA
-9120	main_type	9120	FS	HC12	NA	NA	NA
-9120_qb	subtype	9120	FS	HC12	NA	NA	NA
-9130	main_type	9130	FS	HC12	NA	NA	NA
-9130_end	subtype	9130	FS	HC12	NA	NA	NA
-9130_fm	subtype	9130	FS	HC12	NA	NA	NA
-9150	main_type	9150	FS	HC1	NA	NA	NA
-9160	main_type	9160	FS	HC12	NA	NA	NA
-9190	main_type	9190	FS	HC12	NA	NA	NA
-91E0	main_type	91E0	FS	HC2	NA	NA	NA
-91E0_sf	subtype	91E0	FS	HC2	NA	NA	NA
-91E0_va	subtype	91E0	FS	HC2	NA	NA	NA
-91E0_vc	subtype	91E0	FS	HC2	NA	NA	NA
-91E0_vm	subtype	91E0	FS	HC2	NA	NA	NA
-91E0_vn	subtype	91E0	FS	HC2	NA	NA	NA
-91E0_vo	subtype	91E0	FS	HC2	NA	NA	NA
-91F0	main_type	91F0	FS	HC2	NA	NA	NA
-rbbppm	main_type	rbbppm	FS	HC12	NA	NA	NA
-rbbsf	main_type	rbbsf	FS	HC2	NA	NA	NA
-rbbso	main_type	rbbso	FS	HC2	NA	NA	NA
-rbbsp	main_type	rbbsp	FS	HC1	NA	NA	NA
+type	typelevel	main_type	typeclass	hydr_class	groundw_dep	flood_dep	tag_1	tag_2	tag_3
+1130	main_type	1130	CH	HC3	GD1	NA	DO	NA	NA
+1140	main_type	1140	CH	HC2	GD0	FD2	DO	NA	NA
+1310	main_type	1310	CH	HC2	NA	NA	DIO	NA	NA
+1310_pol	subtype	1310	CH	HC2	GD2	FD2	DI	NA	NA
+1310_zk	subtype	1310	CH	HC2	GD2	FD2	DO	NA	NA
+1310_zv	subtype	1310	CH	HC2	GD2	FD2	DO	NA	NA
+1320	main_type	1320	CH	HC2	GD2	FD2	DO	NA	NA
+1330	main_type	1330	CH	HC2	NA	NA	DIO	NA	NA
+1330_da	subtype	1330	CH	HC2	GD2	FD2	DO	NA	NA
+1330_hpr	subtype	1330	CH	HC2	GD2	FD2	DI	NA	NA
+2110	main_type	2110	CD	HC12	GD0	FD2	NA	NA	NA
+2120	main_type	2120	CD	HC1	GD0	FD0	NA	NA	NA
+2130	main_type	2130	CD	HC12	NA	NA	NA	NA	NA
+2130_had	subtype	2130	CD	HC12	GD1	FD0	NA	NA	NA
+2130_hd	subtype	2130	CD	HC12	GD1	FD0	NA	NA	NA
+2150	main_type	2150	CD	HC1	GD0	FD0	NA	NA	NA
+2160	main_type	2160	CD	HC12	GD1	FD0	NA	NA	NA
+2170	main_type	2170	CD	HC2	GD2	FD0	NA	NA	NA
+2180	main_type	2180	CD	HC12	GD1	FD0	NA	NA	NA
+2190	main_type	2190	CD	HC23	GD2	FD1	NA	NA	NA
+2190_a	subtype	2190	CD	HC3	GD2	NA	SW	NA	NA
+2190_mp	subtype	2190	CD	HC2	GD2	FD0	NA	NA	NA
+2190_overig	subtype	2190	CD	HC2	GD2	FD1	NA	NA	NA
+2310	main_type	2310	ID	HC1	GD0	FD0	NA	NA	NA
+2330	main_type	2330	ID	HC1	GD0	FD0	NA	NA	NA
+2330_bu	subtype	2330	ID	HC1	GD0	FD0	NA	NA	NA
+2330_dw	subtype	2330	ID	HC1	GD0	FD0	NA	NA	NA
+3110	main_type	3110	FW	HC3	GD2	NA	SW	NA	NA
+3130	main_type	3130	FW	HC3	GD2	NA	SW	NA	NA
+3130_aom	subtype	3130	FW	HC3	GD2	NA	SW	NA	NA
+3130_na	subtype	3130	FW	HC3	GD2	NA	SW	NA	NA
+3140	main_type	3140	FW	HC3	GD2	NA	SW	NA	NA
+3150	main_type	3150	FW	HC3	GD2	NA	SW	NA	NA
+3160	main_type	3160	FW	HC3	GD2	NA	SW	NA	NA
+3260	main_type	3260	FW	HC3	GD1	NA	RW	NA	NA
+3270	main_type	3270	FW	HC2	GD1	FD2	NA	NA	NA
+rbbah	main_type	rbbah	FW	HC3	GD2	NA	SW	NA	NA
+4010	main_type	4010	HS	HC2	GD2	FD0	NA	NA	NA
+4030	main_type	4030	HS	HC1	GD0	FD0	NA	NA	NA
+rbbsg	main_type	rbbsg	HS	HC1	GD0	FD0	NA	NA	NA
+rbbsm	main_type	rbbsm	HS	HC2	GD2	FD0	NA	NA	NA
+5130	main_type	5130	SS	HC1	GD0	FD0	NA	NA	NA
+5130_hei	subtype	5130	SS	HC1	GD0	FD0	NA	NA	NA
+5130_kalk	subtype	5130	SS	HC1	GD0	FD0	CT	NA	NA
+6120	main_type	6120	GR	HC2	GD0	FD2	CT	NA	NA
+6210	main_type	6210	GR	HC1	GD0	FD0	CT	NA	NA
+6210_hk	subtype	6210	GR	HC1	GD0	FD0	CT	NA	NA
+6210_sk	subtype	6210	GR	HC1	GD0	FD0	CT	NA	NA
+6230	main_type	6230	GR	HC12	GD1	FD0	NA	NA	NA
+6230_ha	subtype	6230	GR	HC1	GD0	FD0	NA	NA	NA
+6230_hmo	subtype	6230	GR	HC2	GD2	FD0	NA	NA	NA
+6230_hn	subtype	6230	GR	HC1	GD0	FD0	NA	NA	NA
+6230_hnk	subtype	6230	GR	HC1	GD0	FD0	CT	NA	NA
+6410	main_type	6410	GR	HC2	GD2	FD0	NA	NA	NA
+6410_mo	subtype	6410	GR	HC2	GD2	FD0	NA	NA	NA
+6410_ve	subtype	6410	GR	HC2	GD2	FD0	NA	NA	NA
+6430	main_type	6430	GR	HC12	GD1	FD1	NA	NA	NA
+6430_bz	subtype	6430	GR	HC12	GD1	FD1	NA	NA	NA
+6430_hf	subtype	6430	GR	HC2	GD2	FD1	NA	NA	NA
+6430_hw	subtype	6430	GR	HC2	GD2	FD2	NA	NA	NA
+6430_mr	subtype	6430	GR	HC2	GD2	FD2	NA	NA	NA
+6510	main_type	6510	GR	HC12	NA	NA	NA	NA	NA
+6510_hu	subtype	6510	GR	HC12	GD0	FD0	NA	NA	NA
+6510_hua	subtype	6510	GR	HC2	GD2	FD2	NA	NA	NA
+6510_huk	subtype	6510	GR	HC1	GD0	FD0	CT	NA	NA
+6510_hus	subtype	6510	GR	HC2	GD2	FD1	NA	NA	NA
+rbbha	main_type	rbbha	GR	HC1	GD0	FD0	NA	NA	NA
+rbbhc	main_type	rbbhc	GR	HC2	GD2	FD1	NA	NA	NA
+rbbhf	main_type	rbbhf	GR	HC2	GD2	FD1	NA	NA	NA
+rbbhfl	main_type	rbbhfl	GR	HC2	GD2	FD1	NA	NA	NA
+rbbkam	main_type	rbbkam	GR	HC12	GD1	FD0	NA	NA	NA
+rbbkam+	subtype	rbbkam	GR	HC12	NA	NA	NA	NA	NA
+rbbvos	main_type	rbbvos	GR	HC2	GD2	FD1	NA	NA	NA
+rbbvos+	subtype	rbbvos	GR	HC2	NA	NA	NA	NA	NA
+rbbzil	main_type	rbbzil	GR	HC2	GD2	FD2	NA	NA	NA
+rbbzil+	subtype	rbbzil	GR	HC2	NA	NA	NA	NA	NA
+7110	main_type	7110	BMF	HC2	GD2	FD0	NA	NA	NA
+7140	main_type	7140	BMF	HC2	GD2	FD1	NA	NA	NA
+7140_base	subtype	7140	BMF	HC2	GD2	FD1	NA	NA	NA
+7140_meso	subtype	7140	BMF	HC2	GD2	FD1	NA	NA	NA
+7140_mrd	subtype	7140	BMF	HC2	GD2	FD2	NA	NA	NA
+7140_oli	subtype	7140	BMF	HC2	GD2	FD1	NA	NA	NA
+7150	main_type	7150	BMF	HC2	GD2	FD1	NA	NA	NA
+7210	main_type	7210	BMF	HC2	GD2	FD2	NA	NA	NA
+7220	main_type	7220	BMF	HC3	GD2	NA	RW	NA	NA
+7230	main_type	7230	BMF	HC2	GD2	FD0	NA	NA	NA
+rbbmc	main_type	rbbmc	BMF	HC2	GD2	FD1	NA	NA	NA
+rbbmr	main_type	rbbmr	BMF	HC2	GD2	FD1	NA	NA	NA
+rbbms	main_type	rbbms	BMF	HC2	GD2	FD0	NA	NA	NA
+8310	main_type	8310	RC	HC12	GD1	FD0	NA	NA	NA
+9110	main_type	9110	FS	HC1	GD0	FD0	NA	NA	NA
+9120	main_type	9120	FS	HC12	GD0	FD0	NA	NA	NA
+9120_qb	subtype	9120	FS	HC12	GD0	FD0	NA	NA	NA
+9130	main_type	9130	FS	HC12	GD1	FD0	NA	NA	NA
+9130_end	subtype	9130	FS	HC12	GD1	FD0	NA	NA	NA
+9130_fm	subtype	9130	FS	HC12	GD1	FD0	NA	NA	NA
+9150	main_type	9150	FS	HC1	GD0	FD0	NA	NA	NA
+9160	main_type	9160	FS	HC12	GD1	FD0	NA	NA	NA
+9190	main_type	9190	FS	HC12	GD1	FD0	NA	NA	NA
+91E0	main_type	91E0	FS	HC2	GD2	FD1	NA	NA	NA
+91E0_sf	subtype	91E0	FS	HC2	GD2	FD2	NA	NA	NA
+91E0_va	subtype	91E0	FS	HC2	GD2	FD0	NA	NA	NA
+91E0_vc	subtype	91E0	FS	HC2	GD2	FD0	NA	NA	NA
+91E0_vm	subtype	91E0	FS	HC2	GD2	FD1	NA	NA	NA
+91E0_vn	subtype	91E0	FS	HC2	GD2	FD2	NA	NA	NA
+91E0_vo	subtype	91E0	FS	HC2	GD2	FD0	NA	NA	NA
+91F0	main_type	91F0	FS	HC2	GD1	FD2	NA	NA	NA
+rbbppm	main_type	rbbppm	FS	HC12	GD1	FD0	NA	NA	NA
+rbbsf	main_type	rbbsf	FS	HC2	GD2	FD2	NA	NA	NA
+rbbso	main_type	rbbso	FS	HC2	GD2	FD0	NA	NA	NA
+rbbsp	main_type	rbbsp	FS	HC1	GD0	FD0	NA	NA	NA

--- a/inst/textdata/types.tsv
+++ b/inst/textdata/types.tsv
@@ -1,112 +1,112 @@
-type	typelevel	main_type	typeclass	tag_1	tag_2	tag_3
-1130	main_type	1130	CH	DO	HC3	NA
-1140	main_type	1140	CH	DO	HC2	NA
-1310	main_type	1310	CH	DIO	HC2	NA
-1310_pol	subtype	1310	CH	DI	HC2	NA
-1310_zk	subtype	1310	CH	DO	HC2	NA
-1310_zv	subtype	1310	CH	DO	HC2	NA
-1320	main_type	1320	CH	DO	HC2	NA
-1330	main_type	1330	CH	DIO	HC2	NA
-1330_da	subtype	1330	CH	DO	HC2	NA
-1330_hpr	subtype	1330	CH	DI	HC2	NA
-2110	main_type	2110	CD	NA	HC12	NA
-2120	main_type	2120	CD	NA	HC1	NA
-2130	main_type	2130	CD	NA	HC12	NA
-2130_had	subtype	2130	CD	NA	HC12	NA
-2130_hd	subtype	2130	CD	NA	HC12	NA
-2150	main_type	2150	CD	NA	HC1	NA
-2160	main_type	2160	CD	NA	HC12	NA
-2170	main_type	2170	CD	NA	HC2	NA
-2180	main_type	2180	CD	NA	HC12	NA
-2190	main_type	2190	CD	NA	HC23	NA
-2190_a	subtype	2190	CD	NA	HC3	NA
-2190_mp	subtype	2190	CD	NA	HC2	NA
-2190_overig	subtype	2190	CD	NA	HC2	NA
-2310	main_type	2310	ID	NA	HC1	NA
-2330	main_type	2330	ID	NA	HC1	NA
-2330_bu	subtype	2330	ID	NA	HC1	NA
-2330_dw	subtype	2330	ID	NA	HC1	NA
-3110	main_type	3110	FW	SW	HC3	NA
-3130	main_type	3130	FW	SW	HC3	NA
-3130_aom	subtype	3130	FW	SW	HC3	NA
-3130_na	subtype	3130	FW	SW	HC3	NA
-3140	main_type	3140	FW	SW	HC3	NA
-3150	main_type	3150	FW	SW	HC3	NA
-3160	main_type	3160	FW	SW	HC3	NA
-3260	main_type	3260	FW	RW	HC3	NA
-3270	main_type	3270	FW	RW	HC2	NA
-rbbah	main_type	rbbah	FW	SW	HC3	NA
-4010	main_type	4010	HS	NA	HC2	NA
-4030	main_type	4030	HS	NA	HC1	NA
-rbbsg	main_type	rbbsg	HS	NA	HC1	NA
-rbbsm	main_type	rbbsm	HS	NA	HC2	NA
-5130	main_type	5130	SS	NA	HC1	NA
-5130_hei	subtype	5130	SS	NA	HC1	NA
-5130_kalk	subtype	5130	SS	CT	HC1	NA
-6120	main_type	6120	GR	CT	HC2	NA
-6210	main_type	6210	GR	CT	HC1	NA
-6210_hk	subtype	6210	GR	CT	HC1	NA
-6210_sk	subtype	6210	GR	CT	HC1	NA
-6230	main_type	6230	GR	NA	HC12	NA
-6230_ha	subtype	6230	GR	NA	HC1	NA
-6230_hmo	subtype	6230	GR	NA	HC2	NA
-6230_hn	subtype	6230	GR	NA	HC1	NA
-6230_hnk	subtype	6230	GR	CT	HC1	NA
-6410	main_type	6410	GR	NA	HC2	NA
-6410_mo	subtype	6410	GR	NA	HC2	NA
-6410_ve	subtype	6410	GR	NA	HC2	NA
-6430	main_type	6430	GR	NA	HC12	NA
-6430_bz	subtype	6430	GR	NA	HC12	NA
-6430_hf	subtype	6430	GR	NA	HC2	NA
-6430_hw	subtype	6430	GR	NA	HC2	NA
-6430_mr	subtype	6430	GR	NA	HC2	NA
-6510	main_type	6510	GR	NA	HC12	NA
-6510_hu	subtype	6510	GR	NA	HC12	NA
-6510_hua	subtype	6510	GR	NA	HC2	NA
-6510_huk	subtype	6510	GR	CT	HC1	NA
-6510_hus	subtype	6510	GR	NA	HC2	NA
-rbbha	main_type	rbbha	GR	NA	HC1	NA
-rbbhc	main_type	rbbhc	GR	NA	HC2	NA
-rbbhf	main_type	rbbhf	GR	NA	HC2	NA
-rbbhfl	main_type	rbbhfl	GR	NA	HC2	NA
-rbbkam	main_type	rbbkam	GR	NA	HC12	NA
-rbbkam+	subtype	rbbkam	GR	NA	HC12	NA
-rbbvos	main_type	rbbvos	GR	NA	HC2	NA
-rbbvos+	subtype	rbbvos	GR	NA	HC2	NA
-rbbzil	main_type	rbbzil	GR	NA	HC2	NA
-rbbzil+	subtype	rbbzil	GR	NA	HC2	NA
-7110	main_type	7110	BMF	NA	HC2	NA
-7140	main_type	7140	BMF	NA	HC2	NA
-7140_base	subtype	7140	BMF	NA	HC2	NA
-7140_meso	subtype	7140	BMF	NA	HC2	NA
-7140_mrd	subtype	7140	BMF	NA	HC2	NA
-7140_oli	subtype	7140	BMF	NA	HC2	NA
-7150	main_type	7150	BMF	NA	HC2	NA
-7210	main_type	7210	BMF	NA	HC2	NA
-7220	main_type	7220	BMF	NA	HC3	NA
-7230	main_type	7230	BMF	NA	HC2	NA
-rbbmc	main_type	rbbmc	BMF	NA	HC2	NA
-rbbmr	main_type	rbbmr	BMF	NA	HC2	NA
-rbbms	main_type	rbbms	BMF	NA	HC2	NA
-8310	main_type	8310	RC	NA	HC12	NA
-9110	main_type	9110	FS	NA	HC1	NA
-9120	main_type	9120	FS	NA	HC12	NA
-9120_qb	subtype	9120	FS	NA	HC12	NA
-9130	main_type	9130	FS	NA	HC12	NA
-9130_end	subtype	9130	FS	NA	HC12	NA
-9130_fm	subtype	9130	FS	NA	HC12	NA
-9150	main_type	9150	FS	NA	HC1	NA
-9160	main_type	9160	FS	NA	HC12	NA
-9190	main_type	9190	FS	NA	HC12	NA
-91E0	main_type	91E0	FS	NA	HC2	NA
-91E0_sf	subtype	91E0	FS	NA	HC2	NA
-91E0_va	subtype	91E0	FS	NA	HC2	NA
-91E0_vc	subtype	91E0	FS	NA	HC2	NA
-91E0_vm	subtype	91E0	FS	NA	HC2	NA
-91E0_vn	subtype	91E0	FS	NA	HC2	NA
-91E0_vo	subtype	91E0	FS	NA	HC2	NA
-91F0	main_type	91F0	FS	NA	HC2	NA
-rbbppm	main_type	rbbppm	FS	NA	HC12	NA
-rbbsf	main_type	rbbsf	FS	NA	HC2	NA
-rbbso	main_type	rbbso	FS	NA	HC2	NA
-rbbsp	main_type	rbbsp	FS	NA	HC1	NA
+type	typelevel	main_type	typeclass	hydr_class	tag_1	tag_2	tag_3
+1130	main_type	1130	CH	HC3	DO	NA	NA
+1140	main_type	1140	CH	HC2	DO	NA	NA
+1310	main_type	1310	CH	HC2	DIO	NA	NA
+1310_pol	subtype	1310	CH	HC2	DI	NA	NA
+1310_zk	subtype	1310	CH	HC2	DO	NA	NA
+1310_zv	subtype	1310	CH	HC2	DO	NA	NA
+1320	main_type	1320	CH	HC2	DO	NA	NA
+1330	main_type	1330	CH	HC2	DIO	NA	NA
+1330_da	subtype	1330	CH	HC2	DO	NA	NA
+1330_hpr	subtype	1330	CH	HC2	DI	NA	NA
+2110	main_type	2110	CD	HC12	NA	NA	NA
+2120	main_type	2120	CD	HC1	NA	NA	NA
+2130	main_type	2130	CD	HC12	NA	NA	NA
+2130_had	subtype	2130	CD	HC12	NA	NA	NA
+2130_hd	subtype	2130	CD	HC12	NA	NA	NA
+2150	main_type	2150	CD	HC1	NA	NA	NA
+2160	main_type	2160	CD	HC12	NA	NA	NA
+2170	main_type	2170	CD	HC2	NA	NA	NA
+2180	main_type	2180	CD	HC12	NA	NA	NA
+2190	main_type	2190	CD	HC23	NA	NA	NA
+2190_a	subtype	2190	CD	HC3	NA	NA	NA
+2190_mp	subtype	2190	CD	HC2	NA	NA	NA
+2190_overig	subtype	2190	CD	HC2	NA	NA	NA
+2310	main_type	2310	ID	HC1	NA	NA	NA
+2330	main_type	2330	ID	HC1	NA	NA	NA
+2330_bu	subtype	2330	ID	HC1	NA	NA	NA
+2330_dw	subtype	2330	ID	HC1	NA	NA	NA
+3110	main_type	3110	FW	HC3	SW	NA	NA
+3130	main_type	3130	FW	HC3	SW	NA	NA
+3130_aom	subtype	3130	FW	HC3	SW	NA	NA
+3130_na	subtype	3130	FW	HC3	SW	NA	NA
+3140	main_type	3140	FW	HC3	SW	NA	NA
+3150	main_type	3150	FW	HC3	SW	NA	NA
+3160	main_type	3160	FW	HC3	SW	NA	NA
+3260	main_type	3260	FW	HC3	RW	NA	NA
+3270	main_type	3270	FW	HC2	RW	NA	NA
+rbbah	main_type	rbbah	FW	HC3	SW	NA	NA
+4010	main_type	4010	HS	HC2	NA	NA	NA
+4030	main_type	4030	HS	HC1	NA	NA	NA
+rbbsg	main_type	rbbsg	HS	HC1	NA	NA	NA
+rbbsm	main_type	rbbsm	HS	HC2	NA	NA	NA
+5130	main_type	5130	SS	HC1	NA	NA	NA
+5130_hei	subtype	5130	SS	HC1	NA	NA	NA
+5130_kalk	subtype	5130	SS	HC1	CT	NA	NA
+6120	main_type	6120	GR	HC2	CT	NA	NA
+6210	main_type	6210	GR	HC1	CT	NA	NA
+6210_hk	subtype	6210	GR	HC1	CT	NA	NA
+6210_sk	subtype	6210	GR	HC1	CT	NA	NA
+6230	main_type	6230	GR	HC12	NA	NA	NA
+6230_ha	subtype	6230	GR	HC1	NA	NA	NA
+6230_hmo	subtype	6230	GR	HC2	NA	NA	NA
+6230_hn	subtype	6230	GR	HC1	NA	NA	NA
+6230_hnk	subtype	6230	GR	HC1	CT	NA	NA
+6410	main_type	6410	GR	HC2	NA	NA	NA
+6410_mo	subtype	6410	GR	HC2	NA	NA	NA
+6410_ve	subtype	6410	GR	HC2	NA	NA	NA
+6430	main_type	6430	GR	HC12	NA	NA	NA
+6430_bz	subtype	6430	GR	HC12	NA	NA	NA
+6430_hf	subtype	6430	GR	HC2	NA	NA	NA
+6430_hw	subtype	6430	GR	HC2	NA	NA	NA
+6430_mr	subtype	6430	GR	HC2	NA	NA	NA
+6510	main_type	6510	GR	HC12	NA	NA	NA
+6510_hu	subtype	6510	GR	HC12	NA	NA	NA
+6510_hua	subtype	6510	GR	HC2	NA	NA	NA
+6510_huk	subtype	6510	GR	HC1	CT	NA	NA
+6510_hus	subtype	6510	GR	HC2	NA	NA	NA
+rbbha	main_type	rbbha	GR	HC1	NA	NA	NA
+rbbhc	main_type	rbbhc	GR	HC2	NA	NA	NA
+rbbhf	main_type	rbbhf	GR	HC2	NA	NA	NA
+rbbhfl	main_type	rbbhfl	GR	HC2	NA	NA	NA
+rbbkam	main_type	rbbkam	GR	HC12	NA	NA	NA
+rbbkam+	subtype	rbbkam	GR	HC12	NA	NA	NA
+rbbvos	main_type	rbbvos	GR	HC2	NA	NA	NA
+rbbvos+	subtype	rbbvos	GR	HC2	NA	NA	NA
+rbbzil	main_type	rbbzil	GR	HC2	NA	NA	NA
+rbbzil+	subtype	rbbzil	GR	HC2	NA	NA	NA
+7110	main_type	7110	BMF	HC2	NA	NA	NA
+7140	main_type	7140	BMF	HC2	NA	NA	NA
+7140_base	subtype	7140	BMF	HC2	NA	NA	NA
+7140_meso	subtype	7140	BMF	HC2	NA	NA	NA
+7140_mrd	subtype	7140	BMF	HC2	NA	NA	NA
+7140_oli	subtype	7140	BMF	HC2	NA	NA	NA
+7150	main_type	7150	BMF	HC2	NA	NA	NA
+7210	main_type	7210	BMF	HC2	NA	NA	NA
+7220	main_type	7220	BMF	HC3	NA	NA	NA
+7230	main_type	7230	BMF	HC2	NA	NA	NA
+rbbmc	main_type	rbbmc	BMF	HC2	NA	NA	NA
+rbbmr	main_type	rbbmr	BMF	HC2	NA	NA	NA
+rbbms	main_type	rbbms	BMF	HC2	NA	NA	NA
+8310	main_type	8310	RC	HC12	NA	NA	NA
+9110	main_type	9110	FS	HC1	NA	NA	NA
+9120	main_type	9120	FS	HC12	NA	NA	NA
+9120_qb	subtype	9120	FS	HC12	NA	NA	NA
+9130	main_type	9130	FS	HC12	NA	NA	NA
+9130_end	subtype	9130	FS	HC12	NA	NA	NA
+9130_fm	subtype	9130	FS	HC12	NA	NA	NA
+9150	main_type	9150	FS	HC1	NA	NA	NA
+9160	main_type	9160	FS	HC12	NA	NA	NA
+9190	main_type	9190	FS	HC12	NA	NA	NA
+91E0	main_type	91E0	FS	HC2	NA	NA	NA
+91E0_sf	subtype	91E0	FS	HC2	NA	NA	NA
+91E0_va	subtype	91E0	FS	HC2	NA	NA	NA
+91E0_vc	subtype	91E0	FS	HC2	NA	NA	NA
+91E0_vm	subtype	91E0	FS	HC2	NA	NA	NA
+91E0_vn	subtype	91E0	FS	HC2	NA	NA	NA
+91E0_vo	subtype	91E0	FS	HC2	NA	NA	NA
+91F0	main_type	91F0	FS	HC2	NA	NA	NA
+rbbppm	main_type	rbbppm	FS	HC12	NA	NA	NA
+rbbsf	main_type	rbbsf	FS	HC2	NA	NA	NA
+rbbso	main_type	rbbso	FS	HC2	NA	NA	NA
+rbbsp	main_type	rbbsp	FS	HC1	NA	NA	NA

--- a/inst/textdata/types.tsv
+++ b/inst/textdata/types.tsv
@@ -19,7 +19,7 @@ type	typelevel	main_type	typeclass	hydr_class	tag_1	tag_2	tag_3
 2170	main_type	2170	CD	HC2	NA	NA	NA
 2180	main_type	2180	CD	HC12	NA	NA	NA
 2190	main_type	2190	CD	HC23	NA	NA	NA
-2190_a	subtype	2190	CD	HC3	NA	NA	NA
+2190_a	subtype	2190	CD	HC3	SW	NA	NA
 2190_mp	subtype	2190	CD	HC2	NA	NA	NA
 2190_overig	subtype	2190	CD	HC2	NA	NA	NA
 2310	main_type	2310	ID	HC1	NA	NA	NA
@@ -34,7 +34,7 @@ type	typelevel	main_type	typeclass	hydr_class	tag_1	tag_2	tag_3
 3150	main_type	3150	FW	HC3	SW	NA	NA
 3160	main_type	3160	FW	HC3	SW	NA	NA
 3260	main_type	3260	FW	HC3	RW	NA	NA
-3270	main_type	3270	FW	HC2	RW	NA	NA
+3270	main_type	3270	FW	HC2	NA	NA	NA
 rbbah	main_type	rbbah	FW	HC3	SW	NA	NA
 4010	main_type	4010	HS	HC2	NA	NA	NA
 4030	main_type	4030	HS	HC1	NA	NA	NA
@@ -83,7 +83,7 @@ rbbzil+	subtype	rbbzil	GR	HC2	NA	NA	NA
 7140_oli	subtype	7140	BMF	HC2	NA	NA	NA
 7150	main_type	7150	BMF	HC2	NA	NA	NA
 7210	main_type	7210	BMF	HC2	NA	NA	NA
-7220	main_type	7220	BMF	HC3	NA	NA	NA
+7220	main_type	7220	BMF	HC3	RW	NA	NA
 7230	main_type	7230	BMF	HC2	NA	NA	NA
 rbbmc	main_type	rbbmc	BMF	HC2	NA	NA	NA
 rbbmr	main_type	rbbmr	BMF	HC2	NA	NA	NA

--- a/inst/textdata/types.yml
+++ b/inst/textdata/types.yml
@@ -6,7 +6,7 @@
   - typeclass
   - type
   hash: aef5eb0b7174fddf5f625305e88d19cd6f2aceff
-  data_hash: 6b58627a9850cce915616abca006c8b3e9e59d3a
+  data_hash: 63a3e5ab925cb31d50efebfe953c8b67c78a8efc
 type:
   class: factor
   labels:

--- a/inst/textdata/types.yml
+++ b/inst/textdata/types.yml
@@ -5,8 +5,8 @@
   sorting:
   - typeclass
   - type
-  hash: aef5eb0b7174fddf5f625305e88d19cd6f2aceff
-  data_hash: 63a3e5ab925cb31d50efebfe953c8b67c78a8efc
+  hash: 3716361494fa7d0742afaf7cb987f8ad91e0fb52
+  data_hash: 7c8f5cf99897554cd6ef821c5aeb2e22d381c3f4
 type:
   class: factor
   labels:
@@ -413,6 +413,28 @@ hydr_class:
   - 3
   - 4
   - 5
+  ordered: no
+groundw_dep:
+  class: factor
+  labels:
+  - GD0
+  - GD1
+  - GD2
+  index:
+  - 1
+  - 2
+  - 3
+  ordered: no
+flood_dep:
+  class: factor
+  labels:
+  - FD0
+  - FD1
+  - FD2
+  index:
+  - 1
+  - 2
+  - 3
   ordered: no
 tag_1:
   class: character

--- a/inst/textdata/types.yml
+++ b/inst/textdata/types.yml
@@ -5,8 +5,8 @@
   sorting:
   - typeclass
   - type
-  hash: 1b6d1c2a70797685dcea441abeb708cce6c2026a
-  data_hash: 5be6bf7b04a81a1c5023b3e549eb3b793f2fae73
+  hash: aef5eb0b7174fddf5f625305e88d19cd6f2aceff
+  data_hash: 6b58627a9850cce915616abca006c8b3e9e59d3a
 type:
   class: factor
   labels:
@@ -398,6 +398,21 @@ typeclass:
   - 8
   - 9
   - 10
+  ordered: no
+hydr_class:
+  class: factor
+  labels:
+  - HC1
+  - HC12
+  - HC2
+  - HC23
+  - HC3
+  index:
+  - 1
+  - 2
+  - 3
+  - 4
+  - 5
   ordered: no
 tag_1:
   class: character

--- a/man/read_types.Rd
+++ b/man/read_types.Rd
@@ -30,9 +30,8 @@ the language of names & shortnames to be returned in the tibble.}
 }
 \value{
 The \code{types} dataframe as a \code{\link[tibble:tbl_df-class]{tibble}},
-with names & shortnames added for types, typeclasses and tags
+with names & shortnames added for types, attributes and tags
 according to the \code{lang} argument.
-The tibble has 108 rows and 16 variables.
 See \code{\link{types}} for documentation of the data-source's contents.
 See \code{\link{namelist}} for the link between codes or other identifiers
 and the corresponding names (and shortnames).
@@ -41,8 +40,13 @@ The added names and shortnames are represented by the following variables:
 \itemize{
   \item \code{type_name}
   \item \code{type_shortname}
-  \item \code{typeclass_name}: a factor with the level order
-  according to that of \code{typeclass}.
+  \item \code{typeclass_name}
+  \item \code{hydr_class_name}
+  \item \code{hydr_class_shortname}
+  \item \code{groundw_dep_name}
+  \item \code{groundw_dep_shortname}
+  \item \code{flood_dep_name}
+  \item \code{flood_dep_shortname}
   \item \code{tag_1_name}
   \item \code{tag_1_shortname}
   \item \code{tag_2_name}
@@ -50,6 +54,8 @@ The added names and shortnames are represented by the following variables:
   \item \code{tag_3_name}
   \item \code{tag_3_shortname}
 }
+Except for the tags, the names and shortnames are factors with their level
+order according to that of the corresponding attribute.
 }
 \description{
 Returns the included data source \code{\link{types}} as a
@@ -72,7 +78,7 @@ and returns it as a
 A tibble is a dataframe that makes working in the tidyverse a little
 \href{https://r4ds.had.co.nz/tibbles.html}{easier}.
 By default, the data version delivered with the package is used and English
-names (\code{lang = "en"}) are returned for types, typeclasses and tags.
+names (\code{lang = "en"}) are returned for types, attributes and tags.
 }
 \section{Recommended usage}{
 

--- a/man/types.Rd
+++ b/man/types.Rd
@@ -4,7 +4,7 @@
 \alias{types}
 \title{Documentation of included data source 'types'}
 \format{A vc-formatted data source. As such, it corresponds to
-a dataframe with 7 variables:
+a dataframe with several variables:
 \describe{
   \item{type}{Code of the type, as a factor.
   This is the ID for use in diverse workflows and datasets.
@@ -21,17 +21,45 @@ a dataframe with 7 variables:
   \item{typeclass}{A code explained by \code{\link{namelist}},
   corresponding to the typeclass.
   Is a factor.}
+  \item{hydr_class}{A code explained by \code{\link{namelist}},
+  corresponding to the hydrological class.
+  Is a factor.}
+  \item{ground_dep}{A code explained by \code{\link{namelist}},
+  corresponding to the groundwater dependency category.
+  Is a factor.}
+  \item{flood_dep}{A code explained by \code{\link{namelist}},
+  corresponding to the flood dependency category.
+  Is a factor.
+  Note that flood dependency is only defined for (semi-)terrestrial types,
+  hence for aquatic types (hydrological class \code{HC3})
+  it is \code{NA}.}
   \item{tag_1}{Optional tag, e.g. a categorization ID explained
   by \code{\link{namelist}}.
-  Currently used to indicate subcategories within a few typeclasses.}
+  Currently used to indicate subcategories within a few typeclasses,
+  or to differentiate between lotic and lentic aquatic types.}
   \item{tag_2}{Optional tag, e.g. a categorization ID explained
-  by \code{\link{namelist}}.
-  Currently used to indicate the hydrological class.}
+  by \code{\link{namelist}}.}
   \item{tag_3}{Optional tag, e.g. a categorization ID explained
   by \code{\link{namelist}}.} }}
 \source{
-\href{https://docs.google.com/spreadsheets/d/1dK0S1Tt3RlVEh4WrNF5N_-hn0OXiTUVOvsL2JRhSl78}{This googlesheet}.
+Most information comes from
+\href{https://docs.google.com/spreadsheets/d/1dK0S1Tt3RlVEh4WrNF5N_-hn0OXiTUVOvsL2JRhSl78}{this googlesheet}.
 Currently, the googlesheet and the data source are both kept up-to-date.
+However only the 'types' data source is under version control.
+
+The source for the hydrological class attribute is a vc-formatted file
+stored in the package source code.
+It is read by the 'generate_textdata' bookdown project which generates the
+'types' data source.
+The referred vc-formatted file was derived from a yet unpublished database
+on the interrelations
+between types, hydrological classes, environmental compartments and their
+characteristics, and environmental pressures.
+
+The source for the groundwater and flood dependency attributes is
+\href{https://docs.google.com/spreadsheets/d/1bhXgamK28K--MSWF7goKNOWtWPEI149_QCpU-3V_k_E}{this googlesheet}.
+Currently, the googlesheet and the data source are both kept up-to-date.
+However only the 'types' data source is under version control.
 }
 \description{
 'types' is a data source in the
@@ -40,7 +68,8 @@ a checklist of types, represented by their \strong{current} codes, together
 with several attributes.
 A 'type' refers to either a (main) habitat type, a
 habitat subtype or a regionally important biotope (RIB).
-The codes of types, typeclasses and tags are explained in the
+The codes of types, typeclasses and further attributes and tags are
+explained in the
 data source \code{\link{namelist}} (which can accommodate multiple
 languages).
 }

--- a/misc/generate_textdata/10_types.Rmd
+++ b/misc/generate_textdata/10_types.Rmd
@@ -164,7 +164,62 @@ hc_names %>%
     write_vc(namelist_path, root)
 ```
 
+Groundwater and flood dependency:
 
+```{r}
+wdep_ss <- gs_key("1bhXgamK28K--MSWF7goKNOWtWPEI149_QCpU-3V_k_E")
+# gs_browse(wdep_ss)
+type_wdep <-
+    wdep_ss %>%
+    gs_read(ws = "Waterafhankelijke HT en RBB",
+            verbose = FALSE,
+            skip = 2,
+            col_names = FALSE) %>%  
+    select(type = X1, 
+           groundw_dep = X9,
+           flood_dep = X10) %>% 
+    mutate(groundw_dep = case_when(str_detect(groundw_dep, "alle") ~ "GD2",
+                                    str_detect(groundw_dep, "niet") ~ "GD0",
+                                    TRUE ~ "GD1") %>% 
+                        factor,
+           flood_dep = case_when(type %in% subset(type_hydroclass, code == "HC3")$type ~ NA_character_,
+                                 str_detect(flood_dep, "\\(.+\\)") ~ "FD2",
+                                    str_detect(flood_dep, "niet") ~ "FD0",
+                                    TRUE ~ "FD1") %>% 
+                        factor)
+
+wdep_names <- 
+    tribble(
+        ~code, ~nl_name, ~nl_shortname, ~en_name, ~en_shortname,
+        "GD0", "niet grondwaterafhankelijk", "niet grondwaterafhankelijk", "groundwater independent", "groundwater independent",
+        "GD1", "grondwaterafhankelijk op een deel van de locaties", "plaatselijk grondwaterafhankelijk", "groundwater dependent on a part of the locations", "locally groundwater dependent", 
+        "GD2", "grondwaterafhankelijk op (bijna) alle locaties", "(bijna) overal grondwaterafhankelijk", "groundwater dependent on (almost) all locations", "(almost) everywhere groundwater dependent", 
+        "FD0", "niet overstromingsafhankelijk", "niet overstromingsafhankelijk", "flood independent", "flood independent", 
+        "FD1", "overstromingsafhankelijk op een deel van de locaties", "plaatselijk overstromingsafhankelijk", "flood dependent on a part of the locations", "locally flood dependent", 
+        "FD2", "overstromingsafhankelijk op (bijna) alle locaties", "(bijna) overal overstromingsafhankelijk", "flood dependent on (almost) all locations", "(almost) everywhere flood dependent"
+)
+
+wdep_names %>% 
+    select(1, 2, 4) %>% 
+    pivot_longer(cols = -code,
+                 names_to = "lang",
+                 names_pattern = "(..)_.+",
+                 values_to = "name") %>% 
+    inner_join(
+        wdep_names %>% 
+        select(1, 3, 5) %>% 
+        pivot_longer(cols = -code,
+                     names_to = "lang",
+                     names_pattern = "(..)_.+",
+                     values_to = "shortname"),
+        by = c("code", "lang")
+    ) %>% 
+    bind_rows(read_vc(namelist_path, root),
+              .) %>% 
+    write_vc(namelist_path, root)
+```
+
+Note that we have deliberately set flood dependency as `NA` for aquatic types, i.e. from hydrological class 'surface water' (code HC3).
 
 ## Make `types`
 
@@ -197,6 +252,8 @@ source_df %>%
                   mutate(code = factor(code)) %>% 
                   rename(hydr_class = code),
               by = "type") %>% 
+    left_join(type_wdep,
+              by = "type") %>% 
     left_join(en_codelist,
               by = c("tag_1_en" = "name")) %>% 
     select(type,
@@ -204,6 +261,8 @@ source_df %>%
            main_type,
            typeclass,
            hydr_class,
+           groundw_dep,
+           flood_dep,
            tag_1 = code) %>% 
     mutate(typeclass = factor(typeclass, 
                               levels = (.$typeclass %>% unique)),

--- a/misc/generate_textdata/10_types.Rmd
+++ b/misc/generate_textdata/10_types.Rmd
@@ -13,8 +13,10 @@ root <- "../.."
 Reading from the source googlesheet (maintained by Steven De Saeger):
 
 ```{r message=FALSE}
+# the first time, run:
+# gs_auth()
 types_source <- gs_key("1dK0S1Tt3RlVEh4WrNF5N_-hn0OXiTUVOvsL2JRhSl78")
-# gs_browse(types_gs)
+# gs_browse(types_source)
 source_df <-
     types_source %>%
     gs_read(ws = 1, 
@@ -74,7 +76,7 @@ source_df %>%
     write_vc(namelist_path, root)
 ```
 
-## Append extra tags to `namelist`
+## Append extra labels to `namelist`
 
 Information for tag 1:
 

--- a/misc/generate_textdata/10_types.Rmd
+++ b/misc/generate_textdata/10_types.Rmd
@@ -101,7 +101,7 @@ source_df %>%
     write_vc(namelist_path, root)
 ```
 
-Hydrological classes go in tag 2:
+Hydrological classes:
 
 ```{r}
 type_hydroclass <- 
@@ -191,18 +191,21 @@ source_df %>%
     inner_join(en_codelist,
                by = c("typeclass_en" = "name")) %>% 
     rename(typeclass = code) %>% 
+    left_join(type_hydroclass %>% 
+                  mutate(code = factor(code)) %>% 
+                  rename(hydr_class = code),
+              by = "type") %>% 
     left_join(en_codelist,
               by = c("tag_1_en" = "name")) %>% 
     select(type,
            typelevel,
            main_type,
            typeclass,
+           hydr_class,
            tag_1 = code) %>% 
-    left_join(type_hydroclass %>% 
-                  rename(tag_2 = code),
-              by = "type") %>% 
     mutate(typeclass = factor(typeclass, 
                               levels = (.$typeclass %>% unique)),
+           tag_2 = NA %>% as.character,
            tag_3 = NA %>% as.character
            ) %>% 
     arrange(typeclass, 

--- a/misc/generate_textdata/90_check_textdata.Rmd
+++ b/misc/generate_textdata/90_check_textdata.Rmd
@@ -74,6 +74,20 @@ types_check %>%
     nrow == 0
 ```
 
+Which are the frequencies of different combinations of hydrological class, groundwater and flood dependency?
+
+```{r warning=FALSE}
+types_check %>% 
+    count(hydr_class, groundw_dep, flood_dep)
+```
+
+Inspecting the `types` data source, sorted according to the above three variables:
+
+```{r}
+types_check %>% 
+    arrange(hydr_class, groundw_dep, flood_dep)
+```
+
 ## env_pressures
 
 ```{r}


### PR DESCRIPTION
Extended the `types` data source:

- the hydrological class received its own column `hydr_class` (factor with 5 levels).
- groundwater and flood dependency were added (from [this gsheet](https://docs.google.com/spreadsheets/d/1bhXgamK28K--MSWF7goKNOWtWPEI149_QCpU-3V_k_E)) as 3-level factors `groundw_dep` and `flood_dep` (note that the latter is not defined for aquatic types, i.e. if `hydr_class == "HC3"`).

`read_types()` adds names & shortnames for these attributes, as factors with labels in the requested language and with their level order in accordance with the levels of the attribute.

Documentation of `types` & `read_types()` was updated accordingly.