### PR TITLE
.travis.yml: use pkgdown from CRAN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: r
 cache: packages
 
+r_packages:
+  - pkgdown
+
 r_binary_packages:
- - rgdal # For inborutils
+  - rgdal # For inborutils
 
 r_github_packages:
-  - r-lib/pkgdown
   - inbo/inborutils
 
 apt_packages:


### PR DESCRIPTION
Same trick as for [watina](https://github.com/inbo/watina/commit/fc01727c9b66e703fe77f8bca088bb60032c967e) and [inborutils](https://github.com/inbo/inborutils/pull/70).

`pkgdown 1.4.1` should make the badge appear on the home page and will render the URL on the citation page as a hyperlink (which it did not with `pkgdown 1.4.1.9000`)