### PR TITLE
Minor improvement: filter_hab argument

### DIFF
--- a/R/read_habitatdata.R
+++ b/R/read_habitatdata.R
@@ -1063,6 +1063,9 @@ read_habitatstreams <-
 #' the Flemish Region, Belgium.
 #'
 #'
+#' @param filter_hab If \code{TRUE}, only points with (potential) habitat
+#' are returned. The default value is \code{FALSE}.
+#'
 #' @inheritParams read_habitatmap_stdized
 #'
 #' @return
@@ -1083,8 +1086,8 @@ read_habitatstreams <-
 #'     \item \code{source}: original data source of the record.
 #'   }
 #'
-#' Note that the \code{type} variable has implicit \code{NA} values in this
-#' case
+#' Note that, unless \code{filter_hab = TRUE}, the \code{type} variable has
+#' implicit \code{NA} values
 #' (i.e. there is
 #' no factor level to represent the missing values).
 #' If you want this category to appear in certain results, you can add
@@ -1107,6 +1110,7 @@ read_habitatstreams <-
 #'
 #' @importFrom assertthat
 #' assert_that
+#' is.flag
 #' @importFrom stringr
 #' str_sub
 #' @importFrom sf
@@ -1117,13 +1121,16 @@ read_habitatstreams <-
 #' %>%
 #' mutate
 #' select
+#' filter
 #' @export
 read_habitatsprings <-
     function(path = fileman_up("n2khab_data"),
-             file = "10_raw/habitatsprings/habitatsprings.geojson"){
+             file = "10_raw/habitatsprings/habitatsprings.geojson",
+             filter_hab = FALSE){
 
         filepath <- file.path(path, file)
         assert_that(file.exists(filepath))
+        assert_that(is.flag(filter_hab))
 
         habitatsprings <-
             read_sf(filepath) %>%
@@ -1142,6 +1149,7 @@ read_habitatsprings <-
                                    levels),
                 certain = (.data$validity_status == "gecontroleerd")
             ) %>%
+            {if (filter_hab) filter(., !is.na(.$type)) else .} %>%
             select(point_id = .data$id,
                    .data$name,
                    code_orig = .data$habitattype,

--- a/R/read_habitatdata.R
+++ b/R/read_habitatdata.R
@@ -620,6 +620,9 @@ read_watersurfaces <-
 #' }
 #'
 #' @export
+#' @importFrom assertthat
+#' assert_that
+#' is.flag
 #' @importFrom sf
 #' read_sf
 #' st_crs<-
@@ -636,8 +639,12 @@ read_habitatmap <-
              file = "10_raw/habitatmap",
              filter_hab = FALSE){
 
-        habitatmap <- read_sf(file.path(path, file),
-                                   "habitatmap")
+        filepath <- file.path(path, file)
+        assert_that(file.exists(filepath))
+        assert_that(is.flag(filter_hab))
+
+        habitatmap <- read_sf(filepath,
+                              "habitatmap")
 
         colnames(habitatmap) <- tolower(colnames(habitatmap))
 

--- a/R/read_habitatdata.R
+++ b/R/read_habitatdata.R
@@ -588,7 +588,7 @@ read_watersurfaces <-
 #' Given the size of the data source, this function
 #' takes a bit longer than usual to run.
 #'
-#' @param select_hab If \code{TRUE} only polygons that (partially) contain habitat or a regionally
+#' @param filter_hab If \code{TRUE} only polygons that (partially) contain habitat or a regionally
 #' important biotope (RIB) are returned. The default value is \code{FALSE}.
 #'
 #' @inheritParams read_habitatmap_stdized
@@ -634,7 +634,7 @@ read_watersurfaces <-
 read_habitatmap <-
     function(path = fileman_up("n2khab_data"),
              file = "10_raw/habitatmap",
-             select_hab = FALSE){
+             filter_hab = FALSE){
 
         habitatmap <- read_sf(file.path(path, file),
                                    "habitatmap")
@@ -671,7 +671,7 @@ read_habitatmap <-
                    hab_legend = factor(.data$hab_legend)
                    )
 
-        if(select_hab){
+        if (filter_hab) {
 
             # we only select polygons with habitat or RIB, i.e. polygons in habitatmap_stdized data source
             hab_stdized <- read_habitatmap_stdized()

--- a/man/read_habitatmap.Rd
+++ b/man/read_habitatmap.Rd
@@ -7,7 +7,7 @@
 read_habitatmap(
   path = fileman_up("n2khab_data"),
   file = "10_raw/habitatmap",
-  select_hab = FALSE
+  filter_hab = FALSE
 )
 }
 \arguments{
@@ -23,7 +23,7 @@ May include a path prefix.
 The default follows the data management advice in the
 vignette on data storage (run \code{vignette("v020_datastorage")}).}
 
-\item{select_hab}{If \code{TRUE} only polygons that (partially) contain habitat or a regionally
+\item{filter_hab}{If \code{TRUE} only polygons that (partially) contain habitat or a regionally
 important biotope (RIB) are returned. The default value is \code{FALSE}.}
 }
 \value{

--- a/man/read_habitatsprings.Rd
+++ b/man/read_habitatsprings.Rd
@@ -7,7 +7,8 @@ layer}
 \usage{
 read_habitatsprings(
   path = fileman_up("n2khab_data"),
-  file = "10_raw/habitatsprings/habitatsprings.geojson"
+  file = "10_raw/habitatsprings/habitatsprings.geojson",
+  filter_hab = FALSE
 )
 }
 \arguments{
@@ -22,6 +23,9 @@ starting from the working directory.}
 May include a path prefix.
 The default follows the data management advice in the
 vignette on data storage (run \code{vignette("v020_datastorage")}).}
+
+\item{filter_hab}{If \code{TRUE}, only points with (potential) habitat
+are returned. The default value is \code{FALSE}.}
 }
 \value{
 A Simple feature collection of
@@ -41,8 +45,8 @@ Is the site situated within a Special Area of Conservation?
 \item \code{source}: original data source of the record.
 }
 
-Note that the \code{type} variable has implicit \code{NA} values in this
-case
+Note that, unless \code{filter_hab = TRUE}, the \code{type} variable has
+implicit \code{NA} values
 (i.e. there is
 no factor level to represent the missing values).
 If you want this category to appear in certain results, you can add


### PR DESCRIPTION
I suggest to rename the `select_hab` argument of `read_habitatmap()` as `filter_hab` (better resembles `dplyr` verbs).

This PR also implements the argument in `read_habitatsprings()`.