### PR TITLE
Version 0.1.1: hotfix for read_habitatmap_terr()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: n2khab
 Title: Providing Preprocessed Reference Data For Flemish Natura 2000 Habitat Analyses
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(
     person("Floris", "Vanderhaeghe", email = "floris.vanderhaeghe@inbo.be", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6378-6229")), 
     person("Toon", "Westra", email = "toon.westra@inbo.be", role = c("aut"), comment = c(ORCID = "0000-0003-2478-9459")), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# n2khab 0.1.1
+
+## Hotfix
+
+- `read_habitatmap_terr()`: fixed non-functioning argument `keep_aq_types=FALSE` (#60)
+
 # n2khab 0.1.0
 
 ## Features of the first stable release

--- a/R/read_habitatdata.R
+++ b/R/read_habitatdata.R
@@ -719,8 +719,8 @@ read_habitatmap <-
 #' \code{2190_overig}.
 #' There is no exclusion of aquatic types when these coexist with
 #' terrestrial types in the same polygon.
-#' The aquatic types are the types for which \code{tag_2 == "HC3"}
-#' in the \code{\link{types}} data source (\code{tag_2} is the hydrological
+#' The aquatic types are the types for which \code{hydr_class == "HC3"}
+#' in the \code{\link{types}} data source (\code{hydr_class} is the hydrological
 #' class; cf. the output of \code{\link[=read_types]{read_types()}});}
 #' \item{it excludes types which most probably are \emph{no}
 #' habitat or RIB at all.
@@ -870,7 +870,7 @@ read_habitatmap_terr <-
             habmap_terr_types <-
                 habmap_terr_types %>%
                 filter(!(.data$type %in% (types %>%
-                                          filter(.data$tag_2 == "HC3") %>%
+                                          filter(.data$hydr_class == "HC3") %>%
                                           .$type)
                          ))
             # The below step is unneeded (and takes several seconds),

--- a/man/read_habitatmap_terr.Rd
+++ b/man/read_habitatmap_terr.Rd
@@ -89,8 +89,8 @@ In the process, a distinction was also made between \code{2190_a} and
 \code{2190_overig}.
 There is no exclusion of aquatic types when these coexist with
 terrestrial types in the same polygon.
-The aquatic types are the types for which \code{tag_2 == "HC3"}
-in the \code{\link{types}} data source (\code{tag_2} is the hydrological
+The aquatic types are the types for which \code{hydr_class == "HC3"}
+in the \code{\link{types}} data source (\code{hydr_class} is the hydrological
 class; cf. the output of \code{\link[=read_types]{read_types()}});}
 \item{it excludes types which most probably are \emph{no}
 habitat or RIB at all.


### PR DESCRIPTION
The argument `keep_aq_types=FALSE` had no effect, because the old variable `tag_2` (of `types`) was used for filtering instead of `hydr_class`.