### PR TITLE
 read_habitatsprings(): update default data source version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ cache: packages
 r_packages:
   - pkgdown
 
-r_binary_packages:
-  - rgdal # For inborutils
-
 r_github_packages:
   - inbo/inborutils
 

--- a/R/read_habitatdata.R
+++ b/R/read_habitatdata.R
@@ -1179,7 +1179,7 @@ read_habitatsprings <-
              file = "10_raw/habitatsprings/habitatsprings.geojson",
              filter_hab = FALSE,
              units_7220 = FALSE,
-             version = "habitatsprings_2020v1"){
+             version = "habitatsprings_2020v2"){
 
         filepath <- file.path(path, file)
         assert_that(file.exists(filepath))

--- a/man/read_habitatsprings.Rd
+++ b/man/read_habitatsprings.Rd
@@ -10,7 +10,7 @@ read_habitatsprings(
   file = "10_raw/habitatsprings/habitatsprings.geojson",
   filter_hab = FALSE,
   units_7220 = FALSE,
-  version = "habitatsprings_2020v1"
+  version = "habitatsprings_2020v2"
 )
 }
 \arguments{


### PR DESCRIPTION
This is due to an (upcoming) new version of the `habitatsprings` data source on Zenodo by @Patrikoosterlynck. 2 point locations within existing units were added (inbo/n2khab-preprocessing#40).

To be added in release candidate for `0.2.0`.

Meanwhile, fixed an issue with Travis CI which now uses R 4.0.0 (first discussed at inbo/inborutils#81)