### PR TITLE
Textdata: name & code updates

### DIFF
--- a/inst/textdata/namelist.tsv
+++ b/inst/textdata/namelist.tsv
@@ -138,7 +138,7 @@ GW_05.1_terr_group1	en	types from very wet environments	very wet
 GW_05.1_terr_group2	en	types from wet environments	wet
 GW_05.1_terr_group3	en	types from moderately wet environments	moderately wet
 GW_05.1_terr_group4	en	types from moist environments	moist
-GW_05.1_terr_group5	en	types from dry environments	dry
+GW_05.1_terr_group5	en	types from locally moist environments	locally moist
 GW_05.2	en	Groundwater monitoring: environmental pressure 05.2_wet_gw	GW: 05.2_wet_gw
 GW_07.1	en	Groundwater monitoring: environmental pressure 07.1_desal_gw	GW: 07.1_desal_gw
 GW_08.3	en	Groundwater monitoring: environmental pressure 08.3_poll_gw	GW: 08.3_poll_gw
@@ -429,7 +429,7 @@ GW_05.1_terr_group1	nl	types van zeer nat milieu	zeer nat
 GW_05.1_terr_group2	nl	types van nat milieu	nat
 GW_05.1_terr_group3	nl	types van matig nat milieu	matig nat
 GW_05.1_terr_group4	nl	types van vochtig milieu	vochtig
-GW_05.1_terr_group5	nl	types van droog milieu	droog
+GW_05.1_terr_group5	nl	types van lokaal vochtig milieu	lokaal vochtig
 GW_05.2	nl	Grondwatermeetnet: milieudruk 05.2_vernat_gw	GW: 05.2_vernat_gw
 GW_07.1	nl	Grondwatermeetnet: milieudruk 07.1_verzoet_gw	GW: 07.1_verzoet_gw
 GW_08.3	nl	Grondwatermeetnet: milieudruk 08.3_verontr_gw	GW: 08.3_verontr_gw

--- a/inst/textdata/namelist.tsv
+++ b/inst/textdata/namelist.tsv
@@ -132,7 +132,7 @@ GW_03.3_group3	en	types from weakly eutrophic environments	weakly eutrophic
 GW_03.3_group4	en	types from moderately eutrophic to eutrophic environments	(moderately) eutrophic
 GW_04.2	en	Groundwater monitoring: environmental pressure 04.2_acidif_gw	GW: 04.2_acidif_gw
 GW_05.1_aq	en	Groundwater monitoring: environmental pressure 05.1_des_gw: partim aquatic	GW: 05.1_des_gw: aq
-GW_05.1_caves	en	Groundwater monitoring: environmental pressure 05.1_des_gw: partim caves	GW: 05.1_des_gw: caves
+GW_05.1_quarries	en	Groundwater monitoring: environmental pressure 05.1_des_gw: partim marl quarries	GW: 05.1_des_gw: quarries
 GW_05.1_terr	en	Groundwater monitoring: environmental pressure 05.1_des_gw: partim terrestrial	GW: 05.1_des_gw: terr
 GW_05.1_terr_group1	en	types from very wet environments	very wet
 GW_05.1_terr_group2	en	types from wet environments	wet
@@ -213,7 +213,6 @@ SURF_08.2	en	Surfacewater monitoring: environmental pressure 08.2_poll_soil	SURF
 SURF_08.4	en	Surfacewater monitoring: environmental pressure 08.4_poll_sw	SURF: 08.4_poll_sw
 SW	en	Standing water	NA
 aq	en	aquatic	NA
-caves	en	caves	NA
 ep_011	en	11 Change of physical structure to a permanent new state (soil compaction, infrastructure, reprofiling, new substrate, soil transport, ...)	011_struct
 ep_012	en	12 Soil dynamics increase (erosion, soil turbation, sand drift)	012_soildyn_incr
 ep_013	en	13 Soil dynamics decrease (erosion, soil turbation, sand drift)	013_soildyn_decr
@@ -268,6 +267,7 @@ ep_class_10	en	10 Climate change	NA
 focal	en	Focal scheme	NA
 lentic	en	lentic waters	NA
 lotic	en	lotic waters	NA
+quarries	en	marl quarries	NA
 rbbah	en	Brackish to saltish standing waters	Brackish to salty standing waters
 rbbha	en	Species-rich Agrostis grasslands (no 6230 habitat type)	Species-rich Agrostis grasslands (not 6230)
 rbbhc	en	Calthion grasslands	Calthion grasslands
@@ -423,7 +423,7 @@ GW_03.3_group3	nl	types van zwak eutroof milieu	zwak eutroof
 GW_03.3_group4	nl	types van matig eutroof tot eutroof milieu	(matig) eutroof
 GW_04.2	nl	Grondwatermeetnet: milieudruk 04.2_verzu_gw	GW: 04.2_verzu_gw
 GW_05.1_aq	nl	Grondwatermeetnet: milieudruk 05.1_verdro_gw: partim aquatisch	GW: 05.1_verdro_gw: aq
-GW_05.1_caves	nl	Grondwatermeetnet: milieudruk 05.1_verdro_gw: partim grotten	GW: 05.1_verdro_gw: caves
+GW_05.1_quarries	nl	Grondwatermeetnet: milieudruk 05.1_verdro_gw: partim mergelgroeven	GW: 05.1_verdro_gw: quarries
 GW_05.1_terr	nl	Grondwatermeetnet: milieudruk 05.1_verdro_gw: partim terrestrisch	GW: 05.1_verdro_gw: terr
 GW_05.1_terr_group1	nl	types van zeer nat milieu	zeer nat
 GW_05.1_terr_group2	nl	types van nat milieu	nat
@@ -504,7 +504,6 @@ SURF_08.2	nl	Oppervlaktewatermeetnet: milieudruk 08.2_verontr_bod	SURF: 08.2_ver
 SURF_08.4	nl	Oppervlaktewatermeetnet: milieudruk 08.4_verontr_ow	SURF: 08.4_verontr_ow
 SW	nl	Stilstaande wateren	NA
 aq	nl	aquatisch	NA
-caves	nl	grotten	NA
 ep_011	nl	11 Aanpassing van de fysische structuur naar een blijvende nieuwe toestand (bodemcompactie, verharding, herprofilering, nieuw substraat, grondverzet, ...)	011_struct
 ep_011_explan	nl	Aard van het substraat of de ruimtelijke vorm van de fysische standplaats worden veranderd naar een blijvende nieuwe toestand, in zodanige mate dat dit de levensgemeenschap negatief beïnvloedt	NA
 ep_012	nl	12 Toename bodemdynamiek (erosie, omwoeling, verstuiving)	012_boddyn_plus
@@ -587,6 +586,7 @@ ep_class_10	nl	10 Klimaatverandering	NA
 focal	nl	Hoofdmeetnet	NA
 lentic	nl	stilstaande wateren	NA
 lotic	nl	stromende wateren	NA
+quarries	nl	mergelgroeven	NA
 rbbah	nl	brak tot zilt water	brak tot zilt water
 rbbha	nl	soortenrijk, niet habitatwaardig struisgrasvegetatie	soortenrijke struisgrasvegetatie
 rbbhc	nl	dotterbloemgrasland	dotterbloemgrasland

--- a/inst/textdata/namelist.yml
+++ b/inst/textdata/namelist.yml
@@ -6,7 +6,7 @@
   - lang
   - code
   hash: 3345146f5a5902a684bc1b965f00486c82952d94
-  data_hash: c0e778c2dfe772bfc44ee0dfef978b68c84b53ad
+  data_hash: 15a66f5904dd38d4651787e410d6b2544f5d5a30
 code:
   class: character
 lang:

--- a/inst/textdata/namelist.yml
+++ b/inst/textdata/namelist.yml
@@ -6,7 +6,7 @@
   - lang
   - code
   hash: 3345146f5a5902a684bc1b965f00486c82952d94
-  data_hash: 15a66f5904dd38d4651787e410d6b2544f5d5a30
+  data_hash: b2c628e10911ceb4eae99e8faf8c9c8280679ef7
 code:
   class: character
 lang:

--- a/inst/textdata/scheme_types.tsv
+++ b/inst/textdata/scheme_types.tsv
@@ -282,7 +282,7 @@ scheme	type	typegroup
 8	28	NA
 8	30	NA
 8	66	NA
-61	71	NA
+64	71	NA
 9	2	18
 9	3	16
 9	4	16

--- a/inst/textdata/scheme_types.yml
+++ b/inst/textdata/scheme_types.yml
@@ -5,8 +5,8 @@
   sorting:
   - scheme
   - type
-  hash: d53996fb20ed088cbf21c677565f549c7ceabedf
-  data_hash: ae3ae1799e5c494a50c6f1be8317cefa04ec94bf
+  hash: ae0fdabc80affdd71a60d85c35080afb337894c3
+  data_hash: 8d3872d79bc7a5192c34c9dc16d4d2d6e768de20
 scheme:
   class: factor
   labels:
@@ -18,7 +18,7 @@ scheme:
   - GW_03.3
   - GW_04.2
   - GW_05.1_aq
-  - GW_05.1_caves
+  - GW_05.1_quarries
   - GW_05.1_terr
   - GW_05.2
   - GW_07.1
@@ -82,7 +82,7 @@ scheme:
   - 6
   - 7
   - 8
-  - 61
+  - 64
   - 9
   - 10
   - 11

--- a/inst/textdata/schemes.tsv
+++ b/inst/textdata/schemes.tsv
@@ -7,7 +7,7 @@ scheme	programme	attribute_1	attribute_2	attribute_3	spatial_restriction	notes	t
 6	1	3	8	NA	For terrestrial types: restrict to zones with shallow groundwater (in reach of vegetation). Don't exclude locations with types that are '(almost) everywhere groundwater dependent' (GD2).	NA	1	NA	NA
 7	1	3	11	NA	For terrestrial types: restrict to zones with shallow groundwater (in reach of vegetation). Don't exclude locations with types that are '(almost) everywhere groundwater dependent' (GD2).	NA	2	NA	NA
 8	1	3	13	1	Exclude terrestrial (i.e. mire) forms of type 7220, if applicable.	NA	1	NA	NA
-61	1	3	13	3	NA	NA	1	NA	NA
+64	1	3	13	6	NA	NA	1	NA	NA
 9	1	3	13	2	Restrict to zones with shallow groundwater (in reach of vegetation). Exclude aquatic (i.e. rivulet) forms of type 7220. Don't exclude locations with types that are '(almost) everywhere groundwater dependent' (GD2).	NA	1	NA	NA
 10	1	3	14	NA	For terrestrial types: restrict to zones with shallow groundwater (in reach of vegetation). Don't exclude locations with types that are '(almost) everywhere groundwater dependent' (GD2).	NA	2	NA	NA
 11	1	3	21	NA	For terrestrial types: restrict to zones with shallow groundwater (in reach of vegetation). Don't exclude locations with types that are '(almost) everywhere groundwater dependent' (GD2).	NA	2	NA	NA

--- a/inst/textdata/schemes.tsv
+++ b/inst/textdata/schemes.tsv
@@ -6,7 +6,7 @@ scheme	programme	attribute_1	attribute_2	attribute_3	spatial_restriction	notes	t
 5	1	1	34	NA	NA	NA	2	NA	NA
 6	1	3	8	NA	For terrestrial types: restrict to zones with shallow groundwater (in reach of vegetation). Don't exclude locations with types that are '(almost) everywhere groundwater dependent' (GD2).	NA	1	NA	NA
 7	1	3	11	NA	For terrestrial types: restrict to zones with shallow groundwater (in reach of vegetation). Don't exclude locations with types that are '(almost) everywhere groundwater dependent' (GD2).	NA	2	NA	NA
-8	1	3	13	1	Exclude terrestrial (i.e. mire) forms of type 7220, if applicable.	NA	1	NA	NA
+8	1	3	13	1	Exclude terrestrial (i.e. mire) forms of type 7220, if applicable. Exclude locations where the surface water is not connected with (nor affected by) the phreatic aquifer.	NA	1	NA	NA
 64	1	3	13	6	NA	NA	1	NA	NA
 9	1	3	13	2	Restrict to zones with shallow groundwater (in reach of vegetation). Exclude aquatic (i.e. rivulet) forms of type 7220. Don't exclude locations with types that are '(almost) everywhere groundwater dependent' (GD2).	NA	1	NA	NA
 10	1	3	14	NA	For terrestrial types: restrict to zones with shallow groundwater (in reach of vegetation). Don't exclude locations with types that are '(almost) everywhere groundwater dependent' (GD2).	NA	2	NA	NA

--- a/inst/textdata/schemes.yml
+++ b/inst/textdata/schemes.yml
@@ -5,8 +5,8 @@
   sorting:
   - programme
   - scheme
-  hash: 92c1d784b9fac3635a357e47ef8a604dcf8bed96
-  data_hash: 7dc247091b92fc9bc9d7691c582101aa6cf18460
+  hash: d189d370cad2f6ca5b708b73f4c2d6285333b8fa
+  data_hash: 78aed6368154dba1b700bd10c0665a309732e65e
 scheme:
   class: factor
   labels:
@@ -18,7 +18,7 @@ scheme:
   - GW_03.3
   - GW_04.2
   - GW_05.1_aq
-  - GW_05.1_caves
+  - GW_05.1_quarries
   - GW_05.1_terr
   - GW_05.2
   - GW_07.1
@@ -82,7 +82,7 @@ scheme:
   - 6
   - 7
   - 8
-  - 61
+  - 64
   - 9
   - 10
   - 11
@@ -295,15 +295,15 @@ attribute_3:
   class: factor
   labels:
   - aq
-  - caves
   - lentic
   - lotic
+  - quarries
   - terr
   index:
   - 1
-  - 3
   - 4
   - 5
+  - 6
   - 2
   ordered: no
 spatial_restriction:

--- a/inst/textdata/schemes.yml
+++ b/inst/textdata/schemes.yml
@@ -6,7 +6,7 @@
   - programme
   - scheme
   hash: d189d370cad2f6ca5b708b73f4c2d6285333b8fa
-  data_hash: 78aed6368154dba1b700bd10c0665a309732e65e
+  data_hash: 296d38a7a38f2071a479c3e025bdbc699bcb7927
 scheme:
   class: factor
   labels:

--- a/misc/generate_textdata/30_schemes_and_scheme_types.Rmd
+++ b/misc/generate_textdata/30_schemes_and_scheme_types.Rmd
@@ -184,8 +184,7 @@ spat_restr <-
             )
         ) %>% 
     bind_rows(tibble(
-        scheme = c("GW_05.1_aq",
-                   "SURF_012", 
+        scheme = c("SURF_012", 
                    "SURF_03.2", 
                    "SURF_03.4_lotic", 
                    "SURF_064", 
@@ -194,6 +193,13 @@ spat_restr <-
                    "SURF_08.4"),
         spatial_restriction = 
           "Exclude terrestrial (i.e. mire) forms of type 7220, if applicable."
+            )
+        ) %>% 
+    bind_rows(tibble(
+        scheme = "GW_05.1_aq",
+        spatial_restriction = 
+          paste("Exclude terrestrial (i.e. mire) forms of type 7220, if applicable.",
+                "Exclude locations where the surface water is not connected with (nor affected by) the phreatic aquifer.")
             )
         ) %>% 
     mutate(scheme = factor(scheme,

--- a/misc/generate_textdata/30_schemes_and_scheme_types.Rmd
+++ b/misc/generate_textdata/30_schemes_and_scheme_types.Rmd
@@ -88,7 +88,7 @@ schemes_schemetypes <-
                              ifelse(hydr_class_expand == "HC3",
                                     "aq",
                                     ifelse(type == "8310",
-                                           "caves",
+                                           "quarries",
                                            "terr")
                                     ),
                              ifelse(attribute_1 == "SURF" & 
@@ -339,10 +339,10 @@ cbind(code = c("ATM", "SOIL", "GW", "SURF", "INUN"),
                    "Inundatiemeetnet")) %>% 
     rbind(matrix(c("aq", "en", "aquatic",
                    "terr", "en", "terrestrial",
-                   "caves", "en", "caves",
+                   "quarries", "en", "marl quarries",
                    "aq", "nl", "aquatisch",
                    "terr", "nl", "terrestrisch",
-                   "caves", "nl", "grotten",
+                   "quarries", "nl", "mergelgroeven",
                    "lotic", "en", "lotic waters",
                    "lentic", "en", "lentic waters",
                    "lotic", "nl", "stromende wateren",

--- a/misc/generate_textdata/30_schemes_and_scheme_types.Rmd
+++ b/misc/generate_textdata/30_schemes_and_scheme_types.Rmd
@@ -463,8 +463,8 @@ tribble(~nr, ~lang, ~name, ~shortname,
         3, "nl", "types van matig nat milieu", "matig nat",
         4, "en", "types from moist environments", "moist",
         4, "nl", "types van vochtig milieu", "vochtig",
-        5, "en", "types from dry environments", "dry",
-        5, "nl", "types van droog milieu", "droog"
+        5, "en", "types from locally moist environments", "locally moist",
+        5, "nl", "types van lokaal vochtig milieu", "lokaal vochtig"
         ) %>% 
       mutate(code = str_c("GW_05.1_terr_group", code))
   ) %>% 


### PR DESCRIPTION
- update name of typegroup `GW_05.1_terr_group5` (fixes #78)
- rename scheme code `GW_05.1_caves` as `GW_05.1_quarries` (fixes #79)
- extend spatial restriction of scheme `GW_05.1_aq` (fixes #80)