### PR TITLE
Prepare version 0.3.1

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -4,7 +4,7 @@
     "license": "GPL-3.0",
     "upload_type": "software",
     "access_right": "open",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "creators": [
         {
             "name": "Vanderhaeghe, Floris",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: n2khab
 Title: Providing Preprocessed Reference Data For Flemish Natura 2000 Habitat Analyses
-Version: 0.3.0
+Version: 0.3.0.9000
 Authors@R: c(
     person("Floris", "Vanderhaeghe", email = "floris.vanderhaeghe@inbo.be", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6378-6229")), 
     person("Toon", "Westra", email = "toon.westra@inbo.be", role = c("aut"), comment = c(ORCID = "0000-0003-2478-9459")), 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: n2khab
 Title: Providing Preprocessed Reference Data For Flemish Natura 2000 Habitat Analyses
-Version: 0.3.0.9000
+Version: 0.3.1
 Authors@R: c(
     person("Floris", "Vanderhaeghe", email = "floris.vanderhaeghe@inbo.be", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6378-6229")), 
     person("Toon", "Westra", email = "toon.westra@inbo.be", role = c("aut"), comment = c(ORCID = "0000-0003-2478-9459")), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+## n2khab 0.3.1
+
+#### Minor patch
+
+- `read_watersurfaces()` has been limited explicitly to using data source version 'watersurfaces_v1.0'.
+Accommodation of the newer 'watersurfaces_v1.1' is planned for later.
+
 ## n2khab 0.3.0
 
 #### Breaking change

--- a/R/read_habitatdata.R
+++ b/R/read_habitatdata.R
@@ -460,9 +460,13 @@ read_watersurfaces_hab <-
 read_watersurfaces <-
     function(file = file.path(fileman_up("n2khab_data"),
                               "10_raw/watersurfaces"),
-             extended = FALSE){
+             extended = FALSE,
+             version = "watersurfaces_v1.0") {
 
         assert_that(file.exists(file))
+        assert_that(is.string(version))
+
+        version <- match.arg(version)
 
         suppressWarnings(
             watersurfaces <- read_sf(file,

--- a/man/read_watersurfaces.Rd
+++ b/man/read_watersurfaces.Rd
@@ -6,7 +6,8 @@
 \usage{
 read_watersurfaces(
   file = file.path(fileman_up("n2khab_data"), "10_raw/watersurfaces"),
-  extended = FALSE
+  extended = FALSE,
+  version = "watersurfaces_v1.0"
 )
 }
 \arguments{
@@ -23,6 +24,9 @@ variables in the result?
 Currently only applies to \code{wfd_type}; if \code{TRUE}, a variable
 \code{wfd_type_name} is added.
 Defaults to \code{FALSE}.}
+
+\item{version}{Version ID of the data source.
+Defaults to the latest available version defined by the package.}
 }
 \value{
 A Simple feature collection of


### PR DESCRIPTION
`read_watersurfaces()`: limit to currently supported data source version `watersurfaces_v1.0`.
    
This is because a newer version is available in the raw
    data source collection at Zenodo, while its accommodation
    in `n2khab` is planned later.
    https://doi.org/10.5281/zenodo.3386857
