### PR TITLE
generate_textdata: maintenance

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: n2khab
 Title: Providing Preprocessed Reference Data For Flemish Natura 2000 Habitat Analyses
-Version: 0.3.1
+Version: 0.3.1.9000
 Authors@R: c(
     person("Floris", "Vanderhaeghe", email = "floris.vanderhaeghe@inbo.be", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6378-6229")), 
     person("Toon", "Westra", email = "toon.westra@inbo.be", role = c("aut"), comment = c(ORCID = "0000-0003-2478-9459")), 

--- a/misc/generate_textdata/20_env_pressures.Rmd
+++ b/misc/generate_textdata/20_env_pressures.Rmd
@@ -9,7 +9,7 @@ ep_source <- gs_key("1PH6InqJk0ijQF_N7v7IZjarijlqHRBCKhTbDn44skZU")
 source_df <-
     ep_source %>%
     gs_read(ws = gs_ws_ls(ep_source) %>%
-                 tail(1), 
+                 head(1), 
             check.names = T,
             verbose = FALSE)
 ```

--- a/misc/generate_textdata/index.Rmd
+++ b/misc/generate_textdata/index.Rmd
@@ -50,7 +50,7 @@ opts_chunk$set(
 )
 ```
 
-**Note: this is a bookdown project, supposed to be run from within the `misc/generate_textdata` subfolder. You can use the `generate_textdata.Rproj` RStudio project file in this subfolder to run it.**
+**Note: this is a bookdown project, supposed to be run from within the `misc/generate_textdata` subfolder. You can use the `generate_textdata.Rproj` RStudio project file in this subfolder to run it, and run `bookdown::render_book("index.Rmd", "bookdown::html_document2")`. To run in a separate R session, use RStudio's build button, or (for older renv libraries) with R or Rscript (use the right version) in a shell.**
 
 
 

--- a/misc/generate_textdata/index.Rmd
+++ b/misc/generate_textdata/index.Rmd
@@ -37,6 +37,7 @@ output:
 ---
 
 ```{r setup, include=FALSE}
+renv::restore()
 options(stringsAsFactors = FALSE)
 library(tidyverse)
 library(stringr)


### PR DESCRIPTION
Starts new dev version number (aimed at `dev_nextrelease` branch), fixes #99 and adds a few other improvements. After running, all package data sources remained the same.
Compiled result: [generating_textdata.html.zip](https://github.com/inbo/n2khab/files/5694916/generating_textdata.html.zip)
Runs with R 3.6.3, using `renv`. Newest RStudio versions will refuse to compile it with ctrl+shift+B (`rmarkdown` too old); ways to neglect this behaviour are added in the bookdown.