### PR TITLE
Most functions: refer to 'latest data source version' in documentation example

### DIFF
--- a/R/GRTSmh.R
+++ b/R/GRTSmh.R
@@ -300,7 +300,7 @@ convert_base4frac_to_dec <-
 #' \dontrun{
 #' # This example supposes that your working directory or a directory up to 10
 #' # levels above has
-#' # the 'n2khab_data' folder AND that the
+#' # the 'n2khab_data' folder AND that the latest version of the
 #' # 'GRTSmaster_habitats' data source is present in the default subdirectory.
 #' # In all other cases, this example won't work but at least you can consider
 #' # what to do.
@@ -417,7 +417,7 @@ read_GRTSmh <-
 #' \dontrun{
 #' # This example supposes that your working directory or a directory up to 10
 #' # levels above has
-#' # the 'n2khab_data' folder AND that the
+#' # the 'n2khab_data' folder AND that the latest version of the
 #' # 'GRTSmh_base4frac' data source is present in the default subdirectory.
 #' # In all other cases, this example won't work but at least you can consider
 #' # what to do.
@@ -564,7 +564,7 @@ read_GRTSmh_base4frac <-
 #' \dontrun{
 #' # This example supposes that your working directory or a directory up to 10
 #' # levels above has
-#' # the 'n2khab_data' folder AND that the
+#' # the 'n2khab_data' folder AND that the latest version of the
 #' # 'GRTSmh_diffres' data source is present in the default subdirectory.
 #' # In all other cases, this example won't work but at least you can consider
 #' # what to do.

--- a/R/read_habitatdata.R
+++ b/R/read_habitatdata.R
@@ -94,7 +94,8 @@
 #' @examples
 #' \dontrun{
 #' # This example supposes that your working directory or a directory up to 10
-#' # levels above has the 'n2khab_data' folder AND that the 'habitatmap_stdized'
+#' # levels above has the 'n2khab_data' folder AND that the latest version of
+#' # the 'habitatmap_stdized'
 #' # data source is present in the default subdirectory.
 #' # In all other cases, this example won't work but at least you can
 #' # consider what to do.
@@ -262,7 +263,8 @@ read_habitatmap_stdized <-
 #' @examples
 #' \dontrun{
 #' # This example supposes that your working directory or a directory up to 10
-#' # levels above has the 'n2khab_data' folder AND that the 'watersurfaces_hab'
+#' # levels above has the 'n2khab_data' folder AND that the latest version of
+#' # the 'watersurfaces_hab'
 #' # data source is present in the default subdirectory.
 #' # In all other cases, this example won't work but at least you can
 #' # consider what to do.
@@ -609,7 +611,8 @@ read_watersurfaces <-
 #' @examples
 #' \dontrun{
 #' # This example supposes that your working directory or a directory up to 10
-#' # levels above has the 'n2khab_data' folder AND that the 'habitatmap'
+#' # levels above has the 'n2khab_data' folder AND that the latest version of
+#' # the 'habitatmap'
 #' # data source is present in the default subdirectory.
 #' # In all other cases, this example won't work but at least you can
 #' # consider what to do.
@@ -811,7 +814,8 @@ read_habitatmap <-
 #' @examples
 #' \dontrun{
 #' # This example supposes that your working directory or a directory up to 10
-#' # levels above has the 'n2khab_data' folder AND that the 'habitatmap_terr'
+#' # levels above has the 'n2khab_data' folder AND that the latest version of
+#' # the 'habitatmap_terr'
 #' # data source is present in the default subdirectory.
 #' # In all other cases, this example won't work but at least you can
 #' # consider what to do.
@@ -967,7 +971,8 @@ read_habitatmap_terr <-
 #' @examples
 #' \dontrun{
 #' # This example supposes that your working directory or a directory up to 10
-#' # levels above has the 'n2khab_data' folder AND that the 'habitatstreams'
+#' # levels above has the 'n2khab_data' folder AND that the latest version of
+#' # the 'habitatstreams'
 #' # data source is present in the default subdirectory.
 #' # In all other cases, this example won't work but at least you can
 #' # consider what to do.
@@ -1146,7 +1151,8 @@ read_habitatstreams <-
 #' @examples
 #' \dontrun{
 #' # This example supposes that your working directory or a directory up to 10
-#' # levels above has the 'n2khab_data' folder AND that the 'habitatsprings'
+#' # levels above has the 'n2khab_data' folder AND that the latest version of
+#' # the 'habitatsprings'
 #' # data source is present in the default subdirectory.
 #' # In all other cases, this example won't work but at least you can
 #' # consider what to do.
@@ -1338,7 +1344,8 @@ read_habitatsprings <-
 #' @examples
 #' \dontrun{
 #' # This example supposes that your working directory or a directory up to 10
-#' # levels above has the 'n2khab_data' folder AND that the 'habitatquarries'
+#' # levels above has the 'n2khab_data' folder AND that the latest version of
+#' # the 'habitatquarries'
 #' # data source is present in the default subdirectory.
 #' # In all other cases, this example won't work but at least you can
 #' # consider what to do.

--- a/R/read_soilmap.R
+++ b/R/read_soilmap.R
@@ -220,7 +220,8 @@
 #' @examples
 #' \dontrun{
 #' # This example supposes that your working directory or a directory up to 10
-#' # levels above has the 'n2khab_data' folder AND that the 'soilmap_simple'
+#' # levels above has the 'n2khab_data' folder AND that the latest version of
+#' # the 'soilmap_simple'
 #' # data source is present in the default subdirectory.
 #' # In all other cases, this example won't work but at least you can
 #' # consider what to do.

--- a/R/read_watercourses.R
+++ b/R/read_watercourses.R
@@ -82,7 +82,7 @@
 #' @examples
 #' \dontrun{
 #' # This example supposes that your working directory or a directory up to 10
-#' # levels above has the 'n2khab_data' folder AND that the
+#' # levels above has the 'n2khab_data' folder AND that the latest version of the
 #' # 'watercourse_100mseg' data source is present in the default subdirectory.
 #' # In all other cases, this example won't work but at least you can
 #' # consider what to do.

--- a/man/read_GRTSmh.Rd
+++ b/man/read_GRTSmh.Rd
@@ -90,7 +90,7 @@ the corresponding RasterBrick layers named as \code{level0} to \code{level9}.
 \dontrun{
 # This example supposes that your working directory or a directory up to 10
 # levels above has
-# the 'n2khab_data' folder AND that the
+# the 'n2khab_data' folder AND that the latest version of the
 # 'GRTSmaster_habitats' data source is present in the default subdirectory.
 # In all other cases, this example won't work but at least you can consider
 # what to do.

--- a/man/read_GRTSmh_base4frac.Rd
+++ b/man/read_GRTSmh_base4frac.Rd
@@ -63,7 +63,7 @@ So, what really matters is only the notation with many digits, to be
 \dontrun{
 # This example supposes that your working directory or a directory up to 10
 # levels above has
-# the 'n2khab_data' folder AND that the
+# the 'n2khab_data' folder AND that the latest version of the
 # 'GRTSmh_base4frac' data source is present in the default subdirectory.
 # In all other cases, this example won't work but at least you can consider
 # what to do.

--- a/man/read_GRTSmh_diffres.Rd
+++ b/man/read_GRTSmh_diffres.Rd
@@ -107,7 +107,7 @@ outer borders (i.e., not excluding the Brussels Capital Region).
 \dontrun{
 # This example supposes that your working directory or a directory up to 10
 # levels above has
-# the 'n2khab_data' folder AND that the
+# the 'n2khab_data' folder AND that the latest version of the
 # 'GRTSmh_diffres' data source is present in the default subdirectory.
 # In all other cases, this example won't work but at least you can consider
 # what to do.

--- a/man/read_habitatmap.Rd
+++ b/man/read_habitatmap.Rd
@@ -35,7 +35,8 @@ takes a bit longer than usual to run.
 \examples{
 \dontrun{
 # This example supposes that your working directory or a directory up to 10
-# levels above has the 'n2khab_data' folder AND that the 'habitatmap'
+# levels above has the 'n2khab_data' folder AND that the latest version of
+# the 'habitatmap'
 # data source is present in the default subdirectory.
 # In all other cases, this example won't work but at least you can
 # consider what to do.

--- a/man/read_habitatmap_stdized.Rd
+++ b/man/read_habitatmap_stdized.Rd
@@ -97,7 +97,8 @@ following steps:
 \examples{
 \dontrun{
 # This example supposes that your working directory or a directory up to 10
-# levels above has the 'n2khab_data' folder AND that the 'habitatmap_stdized'
+# levels above has the 'n2khab_data' folder AND that the latest version of
+# the 'habitatmap_stdized'
 # data source is present in the default subdirectory.
 # In all other cases, this example won't work but at least you can
 # consider what to do.

--- a/man/read_habitatmap_terr.Rd
+++ b/man/read_habitatmap_terr.Rd
@@ -129,7 +129,8 @@ repository.
 \examples{
 \dontrun{
 # This example supposes that your working directory or a directory up to 10
-# levels above has the 'n2khab_data' folder AND that the 'habitatmap_terr'
+# levels above has the 'n2khab_data' folder AND that the latest version of
+# the 'habitatmap_terr'
 # data source is present in the default subdirectory.
 # In all other cases, this example won't work but at least you can
 # consider what to do.

--- a/man/read_habitatquarries.Rd
+++ b/man/read_habitatquarries.Rd
@@ -85,7 +85,8 @@ Exceptionally they may overlap if such units are situated above each other.
 \examples{
 \dontrun{
 # This example supposes that your working directory or a directory up to 10
-# levels above has the 'n2khab_data' folder AND that the 'habitatquarries'
+# levels above has the 'n2khab_data' folder AND that the latest version of
+# the 'habitatquarries'
 # data source is present in the default subdirectory.
 # In all other cases, this example won't work but at least you can
 # consider what to do.

--- a/man/read_habitatsprings.Rd
+++ b/man/read_habitatsprings.Rd
@@ -89,7 +89,8 @@ the Flemish Region, Belgium.
 \examples{
 \dontrun{
 # This example supposes that your working directory or a directory up to 10
-# levels above has the 'n2khab_data' folder AND that the 'habitatsprings'
+# levels above has the 'n2khab_data' folder AND that the latest version of
+# the 'habitatsprings'
 # data source is present in the default subdirectory.
 # In all other cases, this example won't work but at least you can
 # consider what to do.

--- a/man/read_habitatstreams.Rd
+++ b/man/read_habitatstreams.Rd
@@ -43,7 +43,8 @@ with textual explanation of the values of the \code{source_id} variable.
 \examples{
 \dontrun{
 # This example supposes that your working directory or a directory up to 10
-# levels above has the 'n2khab_data' folder AND that the 'habitatstreams'
+# levels above has the 'n2khab_data' folder AND that the latest version of
+# the 'habitatstreams'
 # data source is present in the default subdirectory.
 # In all other cases, this example won't work but at least you can
 # consider what to do.

--- a/man/read_soilmap.Rd
+++ b/man/read_soilmap.Rd
@@ -245,7 +245,8 @@ the \code{soilmap} data source.
 \examples{
 \dontrun{
 # This example supposes that your working directory or a directory up to 10
-# levels above has the 'n2khab_data' folder AND that the 'soilmap_simple'
+# levels above has the 'n2khab_data' folder AND that the latest version of
+# the 'soilmap_simple'
 # data source is present in the default subdirectory.
 # In all other cases, this example won't work but at least you can
 # consider what to do.

--- a/man/read_watercourse_100mseg.Rd
+++ b/man/read_watercourse_100mseg.Rd
@@ -103,7 +103,7 @@ repository.
 \examples{
 \dontrun{
 # This example supposes that your working directory or a directory up to 10
-# levels above has the 'n2khab_data' folder AND that the
+# levels above has the 'n2khab_data' folder AND that the latest version of the
 # 'watercourse_100mseg' data source is present in the default subdirectory.
 # In all other cases, this example won't work but at least you can
 # consider what to do.

--- a/man/read_watersurfaces_hab.Rd
+++ b/man/read_watersurfaces_hab.Rd
@@ -87,7 +87,8 @@ repository.
 \examples{
 \dontrun{
 # This example supposes that your working directory or a directory up to 10
-# levels above has the 'n2khab_data' folder AND that the 'watersurfaces_hab'
+# levels above has the 'n2khab_data' folder AND that the latest version of
+# the 'watersurfaces_hab'
 # data source is present in the default subdirectory.
 # In all other cases, this example won't work but at least you can
 # consider what to do.


### PR DESCRIPTION
This was also done in 4491ef7 in PR #118. This commit implements this for all other functions, except `read_watersurfaces()` which is done in PR #118.

I think it is good to do this generally, it is the easiest to maintain.