### PR TITLE
Github Actions: also cache package dependencies on Windows

### DIFF
--- a/.github/workflows/R-CMD-check-latest.yaml
+++ b/.github/workflows/R-CMD-check-latest.yaml
@@ -51,7 +51,6 @@ jobs:
         shell: Rscript {0}
 
       - name: Restore (or define new) R package cache
-        if: runner.os != 'Windows'
         uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -42,7 +42,6 @@ jobs:
         shell: Rscript {0}
 
       - name: Restore (or define new) R package cache
-        if: runner.os != 'Windows'
         uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}


### PR DESCRIPTION
The exclusion of Windows in using GHA caching was copied from [check-standard.yaml at r-lib/actions](https://github.com/r-lib/actions/blob/f10a854002ed1d591e0e30e53179d5d8df3195b0/.github/workflows/check-standard.yaml).

Although it may indeed pose problems for specific packages, there are also signs that things have improved since R 4.0 / RTools40. Anyway, currently this works with `n2khab`, so adding this in order to further shorten the duration of checks!