### PR TITLE
Github Actions: conditional installation of system dependencies on macOS

### DIFF
--- a/.github/workflows/R-CMD-check-latest.yaml
+++ b/.github/workflows/R-CMD-check-latest.yaml
@@ -52,6 +52,7 @@ jobs:
 
       - name: Restore (or define new) R package cache
         uses: actions/cache@v2
+        id: cache
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ matrix.config.os }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
@@ -67,7 +68,7 @@ jobs:
           done < <(Rscript -e 'release <- system("lsb_release -rs", intern = TRUE); writeLines(remotes::system_requirements("ubuntu", release))')
 
       - name: Install system dependencies (macOS)
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && steps.cache.outputs.cache-hit != 'true'
         run: |
           brew install pkg-config
           brew install udunits

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -43,6 +43,7 @@ jobs:
 
       - name: Restore (or define new) R package cache
         uses: actions/cache@v2
+        id: cache
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ matrix.config.os }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -57,7 +57,7 @@ jobs:
           done < <(Rscript -e 'release <- system("lsb_release -rs", intern = TRUE); writeLines(remotes::system_requirements("ubuntu", release))')
 
       - name: Install system dependencies (macOS)
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && steps.cache.outputs.cache-hit != 'true'
         run: |
           brew install pkg-config
           brew install udunits


### PR DESCRIPTION
In #123 a patch was added for `macos-latest` to pre-install `udunits` and `gdal`. However this largely inflates check duration, wich is especially annoying as both Ubuntu and Windows now get under 5-6 minutes by #123 and #124 (especially in the presence of an R packages cache).

The following workaround [appeared](https://github.com/inbo/n2khab/runs/2169589444?check_suite_focus=true) to work for now: only install the system dependencies when no package cache is available yet (i.e. on a new branch, for the first commit since 7 days). The problem with lacking sysdeps on macos (#120) arose during the installation of R package dependencies that needed to be built from source; in this case `sf` :smile_cat:.

So when using a package cache and not installing the associated system libraries, the process won't complain about a non-functional `sf` package as long as it isn't re-installed or called! From the first observation, this reduced the check duration from > 11 min to approximately 6 min. Still, check duration seems to easily vary for the macOS machine when repeating the same job - delays seem to occur in this build machine.

When we'd add unit tests to `n2khab` in which `sf` or `raster` are called, then it will be another story. So consider this a hack.