### PR TITLE
GH actions: revert "Merge PR #125 from inbo/macos_sysdeps_conditional"

### DIFF
--- a/.github/workflows/R-CMD-check-latest.yaml
+++ b/.github/workflows/R-CMD-check-latest.yaml
@@ -52,7 +52,6 @@ jobs:
 
       - name: Restore (or define new) R package cache
         uses: actions/cache@v2
-        id: cache
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ matrix.config.os }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
@@ -68,7 +67,7 @@ jobs:
           done < <(Rscript -e 'release <- system("lsb_release -rs", intern = TRUE); writeLines(remotes::system_requirements("ubuntu", release))')
 
       - name: Install system dependencies (macOS)
-        if: runner.os == 'macOS' && steps.cache.outputs.cache-hit != 'true'
+        if: runner.os == 'macOS'
         run: |
           brew install pkg-config
           brew install udunits

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -43,7 +43,6 @@ jobs:
 
       - name: Restore (or define new) R package cache
         uses: actions/cache@v2
-        id: cache
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ matrix.config.os }}-${{ secrets.CACHE_VERSION }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
@@ -58,7 +57,7 @@ jobs:
           done < <(Rscript -e 'release <- system("lsb_release -rs", intern = TRUE); writeLines(remotes::system_requirements("ubuntu", release))')
 
       - name: Install system dependencies (macOS)
-        if: runner.os == 'macOS' && steps.cache.outputs.cache-hit != 'true'
+        if: runner.os == 'macOS'
         run: |
           brew install pkg-config
           brew install udunits


### PR DESCRIPTION
This reverts commit b574c1554921e585ec8b6189ad851d1ef0d83203, reversing
changes made to 84149e37d7f916ca6c52452b861ccccb01201c57.

Fixes https://github.com/inbo/n2khab/issues/126.

It appears that gdal is often needed when checking gdal, contrary to the findings
in https://github.com/inbo/n2khab/pull/125.

Note to self:

```bash
$ git log --format='%C(auto)%h (%ai)%d %s' -n 5 --graph
*   b574c15 (2021-03-23 18:28:33 +0100) (HEAD -> gha_undo_macos, origin/dev_0.5.0, dev_0.5.0) Merge pull request #125 from inbo/macos_sysdeps_conditional
|\  
| * e755404 (2021-03-22 21:09:09 +0100) Github actions, R-CMD-check-latest: conditional cache on macOS
| * a298a17 (2021-03-22 20:50:39 +0100) Github actions, R-CMD-check: macOS fix conditional sysdeps
| * 0a0d8da (2021-03-22 20:47:12 +0100) Github actions, R-CMD-check: on macOS try conditional sysdeps
|/  
*   84149e3 (2021-03-22 19:19:27 +0100) Merge pull request #124 from inbo/gha_windows_cache

$ git revert -m 1 HEAD

$ git log --format='%C(auto)%h (%ai)%d %s' -n 6 --graph
* b3b9515 (2021-03-24 09:20:20 +0100) (HEAD -> gha_undo_macos) GH actions: revert "Merge PR #125 from inbo/macos_sysdeps_conditional" *
*   b574c15 (2021-03-23 18:28:33 +0100) (origin/dev_0.5.0, dev_0.5.0) Merge pull request #125 from inbo/macos_sysdeps_conditional
|\  
| * e755404 (2021-03-22 21:09:09 +0100) Github actions, R-CMD-check-latest: conditional cache on macOS
| * a298a17 (2021-03-22 20:50:39 +0100) Github actions, R-CMD-check: macOS fix conditional sysdeps
| * 0a0d8da (2021-03-22 20:47:12 +0100) Github actions, R-CMD-check: on macOS try conditional sysdeps
|/  
*   84149e3 (2021-03-22 19:19:27 +0100) Merge pull request #124 from inbo/gha_windows_cache
```