### PR TITLE
Updates in generate_textdata

### DIFF
--- a/inst/textdata/namelist.tsv
+++ b/inst/textdata/namelist.tsv
@@ -147,34 +147,34 @@ HC12	en	Dry to moist + Temporarily to permanently wet	Dry + Wet
 HC2	en	Temporarily to permanently wet	Wet
 HC23	en	Temporarily to permanently wet + Surface water	Wet + Surface water
 HC3	en	Surface water	Surface water
-HQ1330	en	Habitat quality scheme: Atlantic salt meadows 	Habitat quality scheme 1330 
-HQ2120	en	Habitat quality scheme: White dunes 	Habitat quality scheme 2120 
-HQ2130	en	Habitat quality scheme: Grey dunes 	Habitat quality scheme 2130 
-HQ2160	en	Habitat quality scheme: Hippophae rhamnoides dunes 	Habitat quality scheme 2160 
-HQ2170	en	Habitat quality scheme: Salix repens dunes 	Habitat quality scheme 2170 
-HQ2180	en	Habitat quality scheme: Wooded dunes 	Habitat quality scheme 2180 
-HQ2190_aq	en	Habitat quality scheme: Dune slack ponds 	Habitat quality scheme 2190_a 
+HQ1330	en	Habitat quality scheme: Atlantic salt meadows	Habitat quality scheme 1330
+HQ2120	en	Habitat quality scheme: White dunes	Habitat quality scheme 2120
+HQ2130	en	Habitat quality scheme: Grey dunes	Habitat quality scheme 2130
+HQ2160	en	Habitat quality scheme: Hippophae rhamnoides dunes	Habitat quality scheme 2160
+HQ2170	en	Habitat quality scheme: Salix repens dunes	Habitat quality scheme 2170
+HQ2180	en	Habitat quality scheme: Wooded dunes	Habitat quality scheme 2180
+HQ2190_aq	en	Habitat quality scheme: Dune slack ponds	Habitat quality scheme 2190_a
 HQ2190_terr	en	Habitat quality scheme: Humid dune slacks (terrestrial)	Habitat quality scheme 2190 (terr)
-HQ2310	en	Habitat quality scheme: Psammophylic heath 	Habitat quality scheme 2310 
-HQ2330	en	Habitat quality scheme: Inland shifting dunes 	Habitat quality scheme 2330 
-HQ3110	en	Habitat quality scheme: Barely buffered standing waters 	Habitat quality scheme 3110 
-HQ3130	en	Habitat quality scheme: Poorly buffered standing waters 	Habitat quality scheme 3130 
-HQ3140	en	Habitat quality scheme: Standing waters with Chara 	Habitat quality scheme 3140 
-HQ3150	en	Habitat quality scheme: Lakes with Stratiotes and Potamogeton 	Habitat quality scheme 3150 
-HQ3160	en	Habitat quality scheme: Dystrophic standing waters 	Habitat quality scheme 3160 
-HQ3270	en	Habitat quality scheme: Rivers with muddy banks 	Habitat quality scheme 3270 
-HQ4010	en	Habitat quality scheme: Wet heaths 	Habitat quality scheme 4010 
-HQ4030	en	Habitat quality scheme: Dry heaths 	Habitat quality scheme 4030 
-HQ6120	en	Habitat quality scheme: Pioneer calcareous sand swards 	Habitat quality scheme 6120 
-HQ6230	en	Habitat quality scheme: Nardus grasslands 	Habitat quality scheme 6230 
-HQ6410	en	Habitat quality scheme: Molinion grasslands 	Habitat quality scheme 6410 
-HQ6510	en	Habitat quality scheme: Arrhenaterion and Alopecurion grasslands 	Habitat quality scheme 6510 
-HQ7140	en	Habitat quality scheme: Transition mires and quaking bogs 	Habitat quality scheme 7140 
-HQ9120	en	Habitat quality scheme: Beech-oak forests with Ilex 	Habitat quality scheme 9120 
-HQ9130	en	Habitat quality scheme: Neutrophilic beech forest 	Habitat quality scheme 9130 
-HQ9160	en	Habitat quality scheme: Oak-hornbeam forests 	Habitat quality scheme 9160 
-HQ9190	en	Habitat quality scheme: Old oak forests 	Habitat quality scheme 9190 
-HQ91E0	en	Habitat quality scheme: Alluvial forests 	Habitat quality scheme 91E0 
+HQ2310	en	Habitat quality scheme: Psammophylic heath	Habitat quality scheme 2310
+HQ2330	en	Habitat quality scheme: Inland shifting dunes	Habitat quality scheme 2330
+HQ3110	en	Habitat quality scheme: Barely buffered standing waters	Habitat quality scheme 3110
+HQ3130	en	Habitat quality scheme: Poorly buffered standing waters	Habitat quality scheme 3130
+HQ3140	en	Habitat quality scheme: Standing waters with Chara	Habitat quality scheme 3140
+HQ3150	en	Habitat quality scheme: Lakes with Stratiotes and Potamogeton	Habitat quality scheme 3150
+HQ3160	en	Habitat quality scheme: Dystrophic standing waters	Habitat quality scheme 3160
+HQ3270	en	Habitat quality scheme: Rivers with muddy banks	Habitat quality scheme 3270
+HQ4010	en	Habitat quality scheme: Wet heaths	Habitat quality scheme 4010
+HQ4030	en	Habitat quality scheme: Dry heaths	Habitat quality scheme 4030
+HQ6120	en	Habitat quality scheme: Pioneer calcareous sand swards	Habitat quality scheme 6120
+HQ6230	en	Habitat quality scheme: Nardus grasslands	Habitat quality scheme 6230
+HQ6410	en	Habitat quality scheme: Molinion grasslands	Habitat quality scheme 6410
+HQ6510	en	Habitat quality scheme: Arrhenaterion and Alopecurion grasslands	Habitat quality scheme 6510
+HQ7140	en	Habitat quality scheme: Transition mires and quaking bogs	Habitat quality scheme 7140
+HQ9120	en	Habitat quality scheme: Beech-oak forests with Ilex	Habitat quality scheme 9120
+HQ9130	en	Habitat quality scheme: Neutrophilic beech forest	Habitat quality scheme 9130
+HQ9160	en	Habitat quality scheme: Oak-hornbeam forests	Habitat quality scheme 9160
+HQ9190	en	Habitat quality scheme: Old oak forests	Habitat quality scheme 9190
+HQ91E0	en	Habitat quality scheme: Alluvial forests	Habitat quality scheme 91E0
 HS	en	Temperate heath and scrub	NA
 ID	en	Inland dunes	NA
 INUN	en	Inundationwater monitoring	NA
@@ -439,34 +439,34 @@ HC12	nl	Droog tot vochtig + Tijdelijk tot permanent nat	Droog + Nat
 HC2	nl	Tijdelijk tot permanent nat	Nat
 HC23	nl	Tijdelijk tot permanent nat + Oppervlaktewater	Nat + Oppervlaktewater
 HC3	nl	Oppervlaktewater	Oppervlaktewater
-HQ1330	nl	Meetnet habitatkwaliteit: Atlantische schorren 	Meetnet habitatkwaliteit 1330 
-HQ2120	nl	Meetnet habitatkwaliteit: wandelende duinen 	Meetnet habitatkwaliteit 2120 
-HQ2130	nl	Meetnet habitatkwaliteit: vastgelegde duinen 	Meetnet habitatkwaliteit 2130 
-HQ2160	nl	Meetnet habitatkwaliteit: duindoornstruwelen 	Meetnet habitatkwaliteit 2160 
-HQ2170	nl	Meetnet habitatkwaliteit: kruipwilgstruwelen 	Meetnet habitatkwaliteit 2170 
-HQ2180	nl	Meetnet habitatkwaliteit: duinbossen 	Meetnet habitatkwaliteit 2180 
-HQ2190_aq	nl	Meetnet habitatkwaliteit: duinplassen 	Meetnet habitatkwaliteit 2190_a 
+HQ1330	nl	Meetnet habitatkwaliteit: Atlantische schorren	Meetnet habitatkwaliteit 1330
+HQ2120	nl	Meetnet habitatkwaliteit: wandelende duinen	Meetnet habitatkwaliteit 2120
+HQ2130	nl	Meetnet habitatkwaliteit: vastgelegde duinen	Meetnet habitatkwaliteit 2130
+HQ2160	nl	Meetnet habitatkwaliteit: duindoornstruwelen	Meetnet habitatkwaliteit 2160
+HQ2170	nl	Meetnet habitatkwaliteit: kruipwilgstruwelen	Meetnet habitatkwaliteit 2170
+HQ2180	nl	Meetnet habitatkwaliteit: duinbossen	Meetnet habitatkwaliteit 2180
+HQ2190_aq	nl	Meetnet habitatkwaliteit: duinplassen	Meetnet habitatkwaliteit 2190_a
 HQ2190_terr	nl	Meetnet habitatkwaliteit: vochtige duinvalleien (terrestrisch)	Meetnet habitatkwaliteit 2190 (terr)
-HQ2310	nl	Meetnet habitatkwaliteit: droge heide op landduinen 	Meetnet habitatkwaliteit 2310 
-HQ2330	nl	Meetnet habitatkwaliteit: open grasland op landduinen 	Meetnet habitatkwaliteit 2330 
-HQ3110	nl	Meetnet habitatkwaliteit: zeer zwakgebufferde vennen 	Meetnet habitatkwaliteit 3110 
-HQ3130	nl	Meetnet habitatkwaliteit: zwakgebufferde vennen 	Meetnet habitatkwaliteit 3130 
-HQ3140	nl	Meetnet habitatkwaliteit: kranswierwateren 	Meetnet habitatkwaliteit 3140 
-HQ3150	nl	Meetnet habitatkwaliteit: van nature eutrofe wateren 	Meetnet habitatkwaliteit 3150 
-HQ3160	nl	Meetnet habitatkwaliteit: dystrofe vennen 	Meetnet habitatkwaliteit 3160 
-HQ3270	nl	Meetnet habitatkwaliteit: voedselrijke slikoevers met bepaalde eenjarige planten 	Meetnet habitatkwaliteit 3270 
-HQ4010	nl	Meetnet habitatkwaliteit: vochtige heide 	Meetnet habitatkwaliteit 4010 
-HQ4030	nl	Meetnet habitatkwaliteit: droge heide 	Meetnet habitatkwaliteit 4030 
-HQ6120	nl	Meetnet habitatkwaliteit: stroomdalgraslanden 	Meetnet habitatkwaliteit 6120 
-HQ6230	nl	Meetnet habitatkwaliteit: heischrale graslanden 	Meetnet habitatkwaliteit 6230 
-HQ6410	nl	Meetnet habitatkwaliteit: blauwgraslanden 	Meetnet habitatkwaliteit 6410 
-HQ6510	nl	Meetnet habitatkwaliteit: soortenrijke glanshavergraslanden 	Meetnet habitatkwaliteit 6510 
-HQ7140	nl	Meetnet habitatkwaliteit: overgangs- en trilveen 	Meetnet habitatkwaliteit 7140 
-HQ9120	nl	Meetnet habitatkwaliteit: beuken-eikenbossen op zure bodem 	Meetnet habitatkwaliteit 9120 
-HQ9130	nl	Meetnet habitatkwaliteit: eiken-beukenbossen met wilde hyacint en parelgras-beukenbossen 	Meetnet habitatkwaliteit 9130 
-HQ9160	nl	Meetnet habitatkwaliteit: eiken-haagbeukenbossen 	Meetnet habitatkwaliteit 9160 
-HQ9190	nl	Meetnet habitatkwaliteit: oude eiken-berkenbossen 	Meetnet habitatkwaliteit 9190 
-HQ91E0	nl	Meetnet habitatkwaliteit: vochtige alluviale bossen 	Meetnet habitatkwaliteit 91E0 
+HQ2310	nl	Meetnet habitatkwaliteit: droge heide op landduinen	Meetnet habitatkwaliteit 2310
+HQ2330	nl	Meetnet habitatkwaliteit: open grasland op landduinen	Meetnet habitatkwaliteit 2330
+HQ3110	nl	Meetnet habitatkwaliteit: zeer zwakgebufferde vennen	Meetnet habitatkwaliteit 3110
+HQ3130	nl	Meetnet habitatkwaliteit: zwakgebufferde vennen	Meetnet habitatkwaliteit 3130
+HQ3140	nl	Meetnet habitatkwaliteit: kranswierwateren	Meetnet habitatkwaliteit 3140
+HQ3150	nl	Meetnet habitatkwaliteit: van nature eutrofe wateren	Meetnet habitatkwaliteit 3150
+HQ3160	nl	Meetnet habitatkwaliteit: dystrofe vennen	Meetnet habitatkwaliteit 3160
+HQ3270	nl	Meetnet habitatkwaliteit: voedselrijke slikoevers met bepaalde eenjarige planten	Meetnet habitatkwaliteit 3270
+HQ4010	nl	Meetnet habitatkwaliteit: vochtige heide	Meetnet habitatkwaliteit 4010
+HQ4030	nl	Meetnet habitatkwaliteit: droge heide	Meetnet habitatkwaliteit 4030
+HQ6120	nl	Meetnet habitatkwaliteit: stroomdalgraslanden	Meetnet habitatkwaliteit 6120
+HQ6230	nl	Meetnet habitatkwaliteit: heischrale graslanden	Meetnet habitatkwaliteit 6230
+HQ6410	nl	Meetnet habitatkwaliteit: blauwgraslanden	Meetnet habitatkwaliteit 6410
+HQ6510	nl	Meetnet habitatkwaliteit: soortenrijke glanshavergraslanden	Meetnet habitatkwaliteit 6510
+HQ7140	nl	Meetnet habitatkwaliteit: overgangs- en trilveen	Meetnet habitatkwaliteit 7140
+HQ9120	nl	Meetnet habitatkwaliteit: beuken-eikenbossen op zure bodem	Meetnet habitatkwaliteit 9120
+HQ9130	nl	Meetnet habitatkwaliteit: eiken-beukenbossen met wilde hyacint en parelgras-beukenbossen	Meetnet habitatkwaliteit 9130
+HQ9160	nl	Meetnet habitatkwaliteit: eiken-haagbeukenbossen	Meetnet habitatkwaliteit 9160
+HQ9190	nl	Meetnet habitatkwaliteit: oude eiken-berkenbossen	Meetnet habitatkwaliteit 9190
+HQ91E0	nl	Meetnet habitatkwaliteit: vochtige alluviale bossen	Meetnet habitatkwaliteit 91E0
 HS	nl	Heiden	NA
 ID	nl	Binnenlandse duinen	NA
 INUN	nl	Inundatiemeetnet	NA

--- a/inst/textdata/namelist.tsv
+++ b/inst/textdata/namelist.tsv
@@ -153,7 +153,7 @@ HQ2130	en	Habitat quality scheme: Grey dunes	Habitat quality scheme 2130
 HQ2160	en	Habitat quality scheme: Hippophae rhamnoides dunes	Habitat quality scheme 2160
 HQ2170	en	Habitat quality scheme: Salix repens dunes	Habitat quality scheme 2170
 HQ2180	en	Habitat quality scheme: Wooded dunes	Habitat quality scheme 2180
-HQ2190	en	Habitat quality scheme: Humid dune slacks	Habitat quality scheme 2190
+HQ2190_aq	en	Habitat quality scheme: Dune slack ponds	Habitat quality scheme 2190_a
 HQ2310	en	Habitat quality scheme: Psammophylic heath	Habitat quality scheme 2310
 HQ2330	en	Habitat quality scheme: Inland shifting dunes	Habitat quality scheme 2330
 HQ3110	en	Habitat quality scheme: Barely buffered standing waters	Habitat quality scheme 3110
@@ -276,10 +276,10 @@ rbbhfl	en	Tall herb communities with Lysimachia vulgaris and Calamagrostis canes
 rbbkam	en	Cynosurion grasslands	Cynosurion grasslands
 rbbkam+	en	Species-rich Cynosurion grasslands	Species-rich Cynosurion grasslands
 rbbmc	en	Tall sedges communities	Tall sedges communities
-rbbmr	en	Reed beds and other Phragmites communities (no habitat type 6430)	Reed beds and other Phragmites communities (not 6430)
+rbbmr	en	Reed beds and other Phragmites communities	Reed beds and other Phragmites communities
 rbbms	en	Small sedge communities (no habitat type 7140)	Small sedge communities (not 7140)
 rbbppm	en	Old, structure rich Pinus sylvestris forest	Old, structure rich Pinus sylvestris forest
-rbbsf	en	Wet Salix scrubs on nutrient rich soil (no habitat type 91E0)	Wet Salix scrubs on nutrient rich soil (not 91E0)
+rbbsf	en	Wet Salix scrubs on nutrient rich soil	Wet Salix scrubs on nutrient rich soil
 rbbsg	en	Cytisus and Ulex scrub	Cytisus and Ulex scrubs
 rbbsm	en	Myrica gale scrubs	Myrica gale scrubs
 rbbso	en	Wet Salix scrubs on acid peaty soil	Wet Salix scrubs on acid peaty soil
@@ -444,7 +444,7 @@ HQ2130	nl	Meetnet habitatkwaliteit: vastgelegde duinen	Meetnet habitatkwaliteit 
 HQ2160	nl	Meetnet habitatkwaliteit: duindoornstruwelen	Meetnet habitatkwaliteit 2160
 HQ2170	nl	Meetnet habitatkwaliteit: kruipwilgstruwelen	Meetnet habitatkwaliteit 2170
 HQ2180	nl	Meetnet habitatkwaliteit: duinbossen	Meetnet habitatkwaliteit 2180
-HQ2190	nl	Meetnet habitatkwaliteit: vochtige duinvalleien	Meetnet habitatkwaliteit 2190
+HQ2190_aq	nl	Meetnet habitatkwaliteit: duinplassen	Meetnet habitatkwaliteit 2190_a
 HQ2310	nl	Meetnet habitatkwaliteit: droge heide op landduinen	Meetnet habitatkwaliteit 2310
 HQ2330	nl	Meetnet habitatkwaliteit: open grasland op landduinen	Meetnet habitatkwaliteit 2330
 HQ3110	nl	Meetnet habitatkwaliteit: zeer zwakgebufferde vennen	Meetnet habitatkwaliteit 3110
@@ -609,3 +609,4 @@ rbbzil	nl	zilverschoongrasland	zilverschoongrasland
 rbbzil+	nl	soortenrijk zilverschoongrasland	soortenrijk zilverschoongrasland
 secondary	nl	Secundair meetnet	NA
 terr	nl	terrestrisch	NA
+HQ2190_terr	NA	NA NA	NA 2190_terr

--- a/inst/textdata/namelist.yml
+++ b/inst/textdata/namelist.yml
@@ -6,7 +6,7 @@
   - lang
   - code
   hash: 3345146f5a5902a684bc1b965f00486c82952d94
-  data_hash: 9ff48efd56e6679ba60c12c46cc76853aa21d404
+  data_hash: 58d7ef69f04229b92d03b892ba079f4616e4b4ca
 code:
   class: character
 lang:

--- a/inst/textdata/namelist.yml
+++ b/inst/textdata/namelist.yml
@@ -6,7 +6,7 @@
   - lang
   - code
   hash: 3345146f5a5902a684bc1b965f00486c82952d94
-  data_hash: 83489b3b819896d9a4c9591b477d7702290cfca5
+  data_hash: 86231058edcd58321f0230b0ab6716affc0d9122
 code:
   class: character
 lang:

--- a/inst/textdata/scheme_types.tsv
+++ b/inst/textdata/scheme_types.tsv
@@ -726,8 +726,9 @@ scheme	type	typegroup
 37	13	NA
 38	14	NA
 39	15	NA
-40	17	NA
-40	18	NA
+61	16	NA
+65	17	NA
+65	18	NA
 41	19	NA
 42	20	NA
 43	22	NA

--- a/inst/textdata/scheme_types.yml
+++ b/inst/textdata/scheme_types.yml
@@ -5,8 +5,8 @@
   sorting:
   - scheme
   - type
-  hash: ae0fdabc80affdd71a60d85c35080afb337894c3
-  data_hash: 5214841794ac5e42efeec807c67afe4746ad01c1
+  hash: 996b90ba309ada058fd4c3cf59ef4521bfd9c4be
+  data_hash: 254b130bf1724301703284797b3adb326c1db1e0
 scheme:
   class: factor
   labels:
@@ -52,7 +52,8 @@ scheme:
   - HQ2160
   - HQ2170
   - HQ2180
-  - HQ2190
+  - HQ2190_aq
+  - HQ2190_terr
   - HQ2310
   - HQ2330
   - HQ3110
@@ -116,7 +117,8 @@ scheme:
   - 37
   - 38
   - 39
-  - 40
+  - 61
+  - 65
   - 41
   - 42
   - 43

--- a/inst/textdata/schemes.tsv
+++ b/inst/textdata/schemes.tsv
@@ -41,7 +41,8 @@ scheme	programme	attribute_1	attribute_2	attribute_3	spatial_restriction	notes	t
 37	2	8	NA	NA	NA	NA	4	NA	NA
 38	2	9	NA	NA	NA	NA	4	NA	NA
 39	2	10	NA	NA	NA	NA	4	NA	NA
-40	2	11	NA	NA	NA	NA	4	NA	NA
+61	2	33	NA	NA	NA	NA	3	NA	NA
+65	2	34	NA	NA	NA	NA	4	NA	NA
 41	2	12	NA	NA	NA	NA	4	NA	NA
 42	2	13	NA	NA	NA	NA	4	NA	NA
 43	2	14	NA	NA	NA	NA	3	NA	NA

--- a/inst/textdata/schemes.yml
+++ b/inst/textdata/schemes.yml
@@ -5,8 +5,8 @@
   sorting:
   - programme
   - scheme
-  hash: d189d370cad2f6ca5b708b73f4c2d6285333b8fa
-  data_hash: ce2a4c8602fc4205b55dcedd93e891015cc39afb
+  hash: b28a62b443678796a29db126dcb4b1e774c20377
+  data_hash: ed075ef64e0a7fbf4ab772afd586e02e2d2e2b87
 scheme:
   class: factor
   labels:
@@ -52,7 +52,8 @@ scheme:
   - HQ2160
   - HQ2170
   - HQ2180
-  - HQ2190
+  - HQ2190_aq
+  - HQ2190_terr
   - HQ2310
   - HQ2330
   - HQ3110
@@ -116,7 +117,8 @@ scheme:
   - 37
   - 38
   - 39
-  - 40
+  - 61
+  - 65
   - 41
   - 42
   - 43
@@ -161,7 +163,8 @@ attribute_1:
   - '2160'
   - '2170'
   - '2180'
-  - '2190'
+  - 2190_a
+  - 2190_terr
   - '2310'
   - '2330'
   - '3110'
@@ -194,7 +197,8 @@ attribute_1:
   - 8
   - 9
   - 10
-  - 11
+  - 33
+  - 34
   - 12
   - 13
   - 14

--- a/misc/generate_textdata/10_types.Rmd
+++ b/misc/generate_textdata/10_types.Rmd
@@ -26,7 +26,7 @@ source_df <-
 
 Writing the namelist a first time:
 
-```{r message=FALSE}
+```{r}
 dummy <- 
     str_c(root, "/", namelist_path, ".*") %>% 
     Sys.glob %>% 
@@ -48,7 +48,7 @@ source_df %>%
         "BMF", "Bogs, mires and fens", 
         "RC", "Rocky habitats and caves", 
         "FS", "Forest and scrub"
-    )) %>% 
+    ), by = "en") %>% 
     gather(key = "lang", value = "name", en:nl) %>% 
     mutate(shortname = NA %>% as.character) %>% 
     write_vc(namelist_path,
@@ -80,7 +80,7 @@ source_df %>%
 
 Information for tag 1:
 
-```{r message=FALSE}
+```{r}
 source_df %>% 
     distinct(nl = Groepering.niveau.2,
            en = Groepering.niveau.2.Eng) %>% 
@@ -95,7 +95,7 @@ source_df %>%
         "SW", "Standing water", 
         "RW", "Running water", 
         "CT", "Calcareous type"
-    )) %>% 
+    ), by = "en") %>% 
     gather(key = "lang", value = "name", en:nl) %>% 
     mutate(shortname = NA %>% as.character) %>% 
     bind_rows(read_vc(namelist_path, root),
@@ -157,7 +157,8 @@ hc_names %>%
         pivot_longer(cols = -code,
                      names_to = "lang",
                      names_pattern = "(..)_.+",
-                     values_to = "shortname")
+                     values_to = "shortname"),
+        by = c("code", "lang")
     ) %>% 
     bind_rows(read_vc(namelist_path, root),
               .) %>% 

--- a/misc/generate_textdata/10_types.Rmd
+++ b/misc/generate_textdata/10_types.Rmd
@@ -13,15 +13,12 @@ root <- "../.."
 Reading from the source googlesheet (maintained by Steven De Saeger):
 
 ```{r message=FALSE}
-# the first time, run:
-# gs_auth()
-types_source <- gs_key("1dK0S1Tt3RlVEh4WrNF5N_-hn0OXiTUVOvsL2JRhSl78")
-# gs_browse(types_source)
+# gs4_browse(types_gs_id)
 source_df <-
-    types_source %>%
-    gs_read(ws = 1, 
-            check.names = T,
-            verbose = FALSE)
+    types_gs_id %>%
+    read_sheet(sheet = 1,
+               .name_repair = make.names) %>% 
+    mutate(across(starts_with("Code"), unlist))
 ```
 
 Writing the namelist a first time:
@@ -167,18 +164,16 @@ hc_names %>%
 
 Groundwater and flood dependency:
 
-```{r}
-wdep_ss <- gs_key("1bhXgamK28K--MSWF7goKNOWtWPEI149_QCpU-3V_k_E")
-# gs_browse(wdep_ss)
+```{r message=FALSE}
+# gs4_browse(wdep_gs_id)
 type_wdep <-
-    wdep_ss %>%
-    gs_read(ws = "Waterafhankelijke HT en RBB",
-            verbose = FALSE,
+    wdep_gs_id %>%
+    read_sheet(sheet = "Waterafhankelijke HT en RBB",
             skip = 2,
             col_names = FALSE) %>%  
-    select(type = X1, 
-           groundw_dep = X9,
-           flood_dep = X10) %>% 
+    select(type = ...1, 
+           groundw_dep = ...9,
+           flood_dep = ...10) %>% 
     mutate(groundw_dep = case_when(str_detect(groundw_dep, "alle") ~ "GD2",
                                     str_detect(groundw_dep, "niet") ~ "GD0",
                                     TRUE ~ "GD1") %>% 

--- a/misc/generate_textdata/20_env_pressures.Rmd
+++ b/misc/generate_textdata/20_env_pressures.Rmd
@@ -5,13 +5,9 @@
 Reading from the source googlesheet:
 
 ```{r message=FALSE}
-ep_source <- gs_key("1PH6InqJk0ijQF_N7v7IZjarijlqHRBCKhTbDn44skZU")
 source_df <-
-    ep_source %>%
-    gs_read(ws = gs_ws_ls(ep_source) %>%
-                 head(1), 
-            check.names = T,
-            verbose = FALSE)
+    ep_gs_id %>%
+    read_sheet(sheet = sheet_names(ep_gs_id)[1])
 ```
 
 Adding multilingual EP names and abbreviations to `namelist`:

--- a/misc/generate_textdata/30_schemes_and_scheme_types.Rmd
+++ b/misc/generate_textdata/30_schemes_and_scheme_types.Rmd
@@ -217,7 +217,7 @@ spat_restr <-
 
 Preparing `schemes` with MNE content:
 
-```{r message=FALSE}
+```{r}
 schemes <- 
   schemes_schemetypes %>% 
     distinct(scheme,
@@ -226,7 +226,7 @@ schemes <-
              attribute_2,
              attribute_3,
              tag_1) %>% 
-    left_join(spat_restr) %>% 
+    left_join(spat_restr, by = "scheme") %>% 
     mutate(notes = NA %>% as.character,
            tag_2 = NA %>% as.character,
            tag_3 = NA %>% as.character
@@ -321,12 +321,13 @@ typegroups <-
 
 Preparing `scheme_types` with MNE content:
 
-```{r message=FALSE}
+```{r}
 scheme_types <- 
   schemes_schemetypes %>% 
     distinct(scheme,
              type) %>% 
-    left_join(typegroups) %>% 
+    left_join(typegroups, 
+              by = c("scheme", "type")) %>% 
     arrange(scheme, type)
 ```
 
@@ -396,7 +397,8 @@ schemes %>%
     rename(name_1 = name) %>% 
     left_join(tibble(lang = c("en", "nl"),
                      name_2 = c("environmental pressure",
-                                "milieudruk"))) %>% 
+                                "milieudruk")),
+              by = "lang") %>% 
     left_join(namelist %>% select(-name),
               by = c("attribute_2" = "code", "lang")) %>% 
     rename(name_3 = shortname) %>% 

--- a/misc/generate_textdata/30_schemes_and_scheme_types.Rmd
+++ b/misc/generate_textdata/30_schemes_and_scheme_types.Rmd
@@ -574,21 +574,21 @@ namelist <- read_vc(namelist_path, root)
 
 schemes_MHQ_names <- schemes_MHQ %>%
   left_join(namelist, by = c("attribute_1" = "code")) %>%
-  mutate(name = paste(ifelse(lang == "en",
-                             "Habitat quality scheme:",
-                             "Meetnet habitatkwaliteit:"),
+  mutate(name = paste0(ifelse(lang == "en",
+                             "Habitat quality scheme: ",
+                             "Meetnet habitatkwaliteit: "),
                       shortname,
                       ifelse(scheme == "HQ2190_terr",
                              ifelse(lang == "en",
-                                    "(terrestrial)", "(terrestrisch)"),
+                                    " (terrestrial)", " (terrestrisch)"),
                              "")
                       ),
-         shortname = paste(ifelse(lang == "en",
-                             "Habitat quality scheme",
-                             "Meetnet habitatkwaliteit"),
+         shortname = paste0(ifelse(lang == "en",
+                             "Habitat quality scheme ",
+                             "Meetnet habitatkwaliteit "),
                       attribute_1,
                       ifelse(scheme == "HQ2190_terr",
-                             "(terr)",
+                             " (terr)",
                              ""))
          ) %>%
   select(code = scheme, lang, name, shortname)

--- a/misc/generate_textdata/30_schemes_and_scheme_types.Rmd
+++ b/misc/generate_textdata/30_schemes_and_scheme_types.Rmd
@@ -19,12 +19,10 @@ schemes_types_nl <-
 Reading a link between older Dutch codes of environmental pressures and the current ep_codes:
 
 ```{r message=FALSE}
-ws_list <- gs_ws_ls(ep_source)
+ws_list <- sheet_names(ep_gs_id)
 ep_codes <- 
-    ep_source %>%
-    gs_read(ws = ws_list[str_detect(ws_list, "\\ 1.0\\ ")], 
-            check.names = T,
-            verbose = FALSE) %>% 
+    ep_gs_id %>%
+    read_sheet(sheet = ws_list[str_detect(ws_list, "\\ 1.0\\ ")]) %>% 
     select(ep_code = Environmental_pressure_code,
            ep_code_nl = Environmental_pressure_code_NL_OLD) %>% 
     mutate(ep_code = factor(ep_code,
@@ -250,15 +248,13 @@ schemes <-
 Collecting typegroup information to join on type:
 
 ```{r message=FALSE}
-tg_source <- gs_key("1n2ohvuLEK_anX37gxlanQXRGotweMVonFxKxtfTcuZI")
-ws_list <- gs_ws_ls(tg_source)
+ws_list <- sheet_names(tg_gs_id)
 
 typegroups <- 
     
-    tg_source %>%
-    gs_read(ws = ws_list[str_detect(ws_list, "Eutrofiëring")], 
-            check.names = T,
-            verbose = FALSE) %>% 
+    tg_gs_id %>%
+    read_sheet(sheet = ws_list[str_detect(ws_list, "Eutrofiëring")],
+               .name_repair = make.names) %>% 
     slice(2:n()) %>% 
     expand_grid(scheme = c("GW_03.3",
                            "SURF_03.4_lentic")
@@ -268,10 +264,9 @@ typegroups <-
            typegroup = Cluster.voedselrijkdom) %>% 
     
     bind_rows(
-        tg_source %>%
-        gs_read(ws = ws_list[str_detect(ws_list, "GW_05\\.1")], 
-                check.names = T,
-                verbose = FALSE) %>% 
+        tg_gs_id %>%
+        read_sheet(sheet = "GW_05.1 (XG3)",
+                   .name_repair = make.names) %>% 
         filter(Type %in% 
                  (schemes_schemetypes %>% 
                     filter(scheme == "GW_05.1_terr") %>% 
@@ -284,10 +279,9 @@ typegroups <-
     ) %>% 
     
     bind_rows(
-        tg_source %>%
-        gs_read(ws = ws_list[str_detect(ws_list, "ATM_03\\.1")], 
-                check.names = T,
-                verbose = FALSE) %>% 
+        tg_gs_id %>%
+        read_sheet(sheet = ws_list[str_detect(ws_list, "ATM_03\\.1")],
+                   .name_repair = make.names) %>% 
         mutate(scheme = "ATM_03.1") %>% 
         select(scheme,
                type = Type,
@@ -295,10 +289,9 @@ typegroups <-
     ) %>% 
     
     bind_rows(
-        tg_source %>%
-        gs_read(ws = ws_list[str_detect(ws_list, "ATM_04\\.1")], 
-                check.names = T,
-                verbose = FALSE) %>% 
+        tg_gs_id %>%
+        read_sheet(sheet = ws_list[str_detect(ws_list, "ATM_04\\.1")],
+                   .name_repair = make.names) %>% 
         mutate(scheme = "ATM_04.1") %>% 
         select(scheme,
                type = Type,
@@ -495,8 +488,9 @@ tribble(~nr, ~lang, ~name, ~shortname,
 Writing `schemes`.
 
 ```{r message=FALSE}
-schemes_MHQ <- gs_key("1PU9MDyJKZz2DOrKqb-SIIVmSaR1mh4Ke6v0WCqhr8t4") %>%
-  gs_read(ws = 1) %>%
+schemes_MHQ <- 
+  mhq_gs_id %>%
+  read_sheet(sheet = 1) %>%
   mutate(attribute_1 = ifelse(attribute_1 == 91, 
                               "91E0", 
                               as.character(attribute_1)),
@@ -545,9 +539,11 @@ schemes %>%
 Writing `scheme_types`.
 
 ```{r}
-scheme_type_MHQ <- gs_key("1PU9MDyJKZz2DOrKqb-SIIVmSaR1mh4Ke6v0WCqhr8t4") %>%
-  gs_read(ws = 2) %>%
-  mutate(scheme = factor(scheme))
+scheme_type_MHQ <- 
+  mhq_gs_id %>%
+  read_sheet(sheet = 2) %>%
+  mutate(scheme = factor(scheme),
+         type = unlist(type))
   
 scheme_types %>%
   bind_rows(scheme_type_MHQ) %>%

--- a/misc/generate_textdata/30_schemes_and_scheme_types.Rmd
+++ b/misc/generate_textdata/30_schemes_and_scheme_types.Rmd
@@ -64,6 +64,7 @@ schemes_schemetypes <-
            attribute_2 = Druk,
            tag_1 = MaxMilieudrukkengroep,
            type = Vegcode) %>% 
+    mutate(type = as.character(type)) %>% 
     inner_join(types_hc, by = "type") %>% 
     mutate(
         programme = "MNE" %>% factor,
@@ -111,11 +112,11 @@ schemes_schemetypes <-
                        "focal",
                        "secondary") %>% 
                 factor,
-        type = as.character(type) %>% 
-                factor(levels = 
-                           types %>% 
-                           .$type %>% 
-                           levels)
+        type = factor(type,
+                      levels = 
+                        types %>% 
+                        .$type %>% 
+                        levels)
     ) %>% 
     select(-hydr_class_expand) %>% 
     distinct() %>% 

--- a/misc/generate_textdata/index.Rmd
+++ b/misc/generate_textdata/index.Rmd
@@ -42,7 +42,8 @@ options(stringsAsFactors = FALSE)
 library(tidyverse)
 library(stringr)
 library(knitr)
-library(googlesheets)
+library(googlesheets4)
+local_gs4_quiet()
 library(git2rdata)
 opts_chunk$set(
   echo = TRUE,
@@ -52,6 +53,14 @@ opts_chunk$set(
 
 **Note: this is a bookdown project, supposed to be run from within the `misc/generate_textdata` subfolder. You can use the `generate_textdata.Rproj` RStudio project file in this subfolder to run it, and run `bookdown::render_book("index.Rmd", "bookdown::html_document2")`. To run in a separate R session, use RStudio's build button, or (for older renv libraries) with R or Rscript (use the right version) in a shell.**
 
+```{r}
+# IDs of all involved googlesheets
+types_gs_id <- "1dK0S1Tt3RlVEh4WrNF5N_-hn0OXiTUVOvsL2JRhSl78"
+wdep_gs_id <- "1bhXgamK28K--MSWF7goKNOWtWPEI149_QCpU-3V_k_E"
+ep_gs_id <- "1PH6InqJk0ijQF_N7v7IZjarijlqHRBCKhTbDn44skZU"
+tg_gs_id <- "1n2ohvuLEK_anX37gxlanQXRGotweMVonFxKxtfTcuZI"
+mhq_gs_id <- "1PU9MDyJKZz2DOrKqb-SIIVmSaR1mh4Ke6v0WCqhr8t4"
+```
 
 
 

--- a/misc/generate_textdata/renv.lock
+++ b/misc/generate_textdata/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "3.6.3",
+    "Version": "4.1.1",
     "Repositories": [
       {
         "Name": "RStudio",
@@ -17,47 +17,33 @@
     ]
   },
   "Packages": {
-    "BH": {
-      "Package": "BH",
-      "Version": "1.72.0-3",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "8f9ce74c6417d61f0782cbae5fd2b7b0"
-    },
     "DBI": {
       "Package": "DBI",
-      "Version": "1.1.0",
+      "Version": "1.1.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "4744be45519d675af66c28478720fce5"
-    },
-    "DT": {
-      "Package": "DT",
-      "Version": "0.13",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "a16cb2832248c7cff5a6f505e2aea45b"
+      "Hash": "030aaec5bc6553f35347cbb1e70b1a17"
     },
     "MASS": {
       "Package": "MASS",
-      "Version": "7.3-51.5",
+      "Version": "7.3-54",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "9efe80472b21189ebab1b74169808c26"
+      "Hash": "0e59129db205112e3963904db67fd0dc"
     },
     "Matrix": {
       "Package": "Matrix",
-      "Version": "1.2-18",
+      "Version": "1.3-4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "08588806cba69f04797dab50627428ed"
+      "Hash": "4ed05e9c9726267e4a5872e09c04587c"
     },
     "R6": {
       "Package": "R6",
-      "Version": "2.4.1",
+      "Version": "2.5.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "292b54f8f4b94669b08f94e5acce6be2"
+      "Hash": "470851b6d5d0ac559e9d01bb352b4021"
     },
     "RColorBrewer": {
       "Package": "RColorBrewer",
@@ -68,10 +54,10 @@
     },
     "Rcpp": {
       "Package": "Rcpp",
-      "Version": "1.0.4.6",
+      "Version": "1.0.7",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "e652f23d8b1807cc975c51410d05b72f"
+      "Hash": "dab19adae4440ae55aa8a9d238b246bb"
     },
     "askpass": {
       "Package": "askpass",
@@ -89,10 +75,10 @@
     },
     "backports": {
       "Package": "backports",
-      "Version": "1.1.6",
+      "Version": "1.2.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "3997fd62345a616e59e8161ee0a5816f"
+      "Hash": "644043219fc24e190c2f620c1a380a69"
     },
     "base64enc": {
       "Package": "base64enc",
@@ -101,12 +87,33 @@
       "Repository": "CRAN",
       "Hash": "543776ae6848fde2f48ff3816d0628bc"
     },
-    "bookdown": {
-      "Package": "bookdown",
-      "Version": "0.18",
+    "bit": {
+      "Package": "bit",
+      "Version": "4.0.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "72e9c52caf3f7aacb4e368b75f6ec72a"
+      "Hash": "f36715f14d94678eea9933af927bc15d"
+    },
+    "bit64": {
+      "Package": "bit64",
+      "Version": "4.0.5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "9fe98599ca456d6552421db0d6772d8f"
+    },
+    "blob": {
+      "Package": "blob",
+      "Version": "1.2.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "dc5f7a6598bb025d20d66bb758f12879"
+    },
+    "bookdown": {
+      "Package": "bookdown",
+      "Version": "0.23",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "bc07f4b5b93bbf21075429e0c7e090f8"
     },
     "brew": {
       "Package": "brew",
@@ -115,19 +122,33 @@
       "Repository": "CRAN",
       "Hash": "92a5f887f9ae3035ac7afde22ba73ee9"
     },
-    "broom": {
-      "Package": "broom",
-      "Version": "0.5.5",
+    "brio": {
+      "Package": "brio",
+      "Version": "1.1.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "70ec3aef8a0df13661bf6cc2ff877d61"
+      "Hash": "2f01e16ff9571fe70381c7b9ae560dc4"
+    },
+    "broom": {
+      "Package": "broom",
+      "Version": "0.7.9",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "9b1e2c1f75b349e3ffa7e9c69eec0c52"
+    },
+    "cachem": {
+      "Package": "cachem",
+      "Version": "1.0.6",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "648c5b3d71e6a37e3043617489a0a0e9"
     },
     "callr": {
       "Package": "callr",
-      "Version": "3.4.3",
+      "Version": "3.7.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "643163a00cb536454c624883a10ae0bc"
+      "Hash": "461aa75a11ce2400245190ef5d3995df"
     },
     "cellranger": {
       "Package": "cellranger",
@@ -138,31 +159,24 @@
     },
     "cli": {
       "Package": "cli",
-      "Version": "2.0.2",
+      "Version": "3.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "ff0becff7bfdfe3f75d29aff8f3172dd"
+      "Hash": "e3ae5d68dea0c55a12ea12a9fda02e61"
     },
     "clipr": {
       "Package": "clipr",
-      "Version": "0.7.0",
+      "Version": "0.7.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "08cf4045c149a0f0eaf405324c7495bd"
-    },
-    "clisymbols": {
-      "Package": "clisymbols",
-      "Version": "1.2.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "96c01552bfd5661b9bbdefbc762f4bcd"
+      "Hash": "ebaa97ac99cc2daf04e77eecc7b781d7"
     },
     "colorspace": {
       "Package": "colorspace",
-      "Version": "1.4-1",
+      "Version": "2.0-2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "6b436e95723d1f0e861224dd9b094dfb"
+      "Hash": "6baccb763ee83c0bd313460fdb8b8a84"
     },
     "commonmark": {
       "Package": "commonmark",
@@ -171,75 +185,96 @@
       "Repository": "CRAN",
       "Hash": "0f22be39ec1d141fd03683c06f3a6e67"
     },
-    "covr": {
-      "Package": "covr",
-      "Version": "3.5.0",
+    "cpp11": {
+      "Package": "cpp11",
+      "Version": "0.3.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "cbc6df1ef6ee576f844f973c1fc04ab4"
+      "Hash": "e02edab2bc389c5e4b12949b13df44f2"
     },
     "crayon": {
       "Package": "crayon",
-      "Version": "1.3.4",
+      "Version": "1.4.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "0d57bc8e27b7ba9e45dba825ebc0de6b"
+      "Hash": "e75525c55c70e5f4f78c9960a4b402e9"
     },
-    "crosstalk": {
-      "Package": "crosstalk",
-      "Version": "1.1.0.1",
+    "credentials": {
+      "Package": "credentials",
+      "Version": "1.3.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "ae55f5d7c02f0ab43c58dd050694f2b4"
+      "Hash": "db9463f8f96444ac790bef2076048699"
     },
     "curl": {
       "Package": "curl",
-      "Version": "4.3",
+      "Version": "4.3.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "2b7d10581cc730804e9ed178c8374bd6"
+      "Hash": "022c42d49c28e95d69ca60446dbabf88"
+    },
+    "data.table": {
+      "Package": "data.table",
+      "Version": "1.14.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "d1b8b1a821ee564a3515fa6c6d5c52dc"
     },
     "dbplyr": {
       "Package": "dbplyr",
-      "Version": "1.4.2",
+      "Version": "2.1.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "022c8630abecb00f22740d021ab89595"
+      "Hash": "1f37fa4ab2f5f7eded42f78b9a887182"
     },
     "desc": {
       "Package": "desc",
-      "Version": "1.2.0",
+      "Version": "1.3.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "6c8fe8fa26a23b79949375d372c7b395"
+      "Hash": "b6963166f7f10b970af1006c462ce6cd"
     },
     "devtools": {
       "Package": "devtools",
-      "Version": "2.2.2",
+      "Version": "2.4.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "e12b66f9f6dc41b765b047b4df4b4a38"
+      "Hash": "048d0b914d2cea61f440d35dd3cbddac"
+    },
+    "diffobj": {
+      "Package": "diffobj",
+      "Version": "0.3.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "feb5b7455eba422a2c110bb89852e6a3"
     },
     "digest": {
       "Package": "digest",
-      "Version": "0.6.25",
+      "Version": "0.6.27",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "f697db7d92b7028c4b3436e9603fb636"
+      "Hash": "a0cbe758a531d054b537d16dff4d58a1"
     },
     "dplyr": {
       "Package": "dplyr",
-      "Version": "0.8.5",
+      "Version": "1.0.7",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "57a42ddf80f429764ff7987128c3fd0a"
+      "Hash": "36f1ae62f026c8ba9f9b5c9a08c03297"
+    },
+    "dtplyr": {
+      "Package": "dtplyr",
+      "Version": "1.1.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "1e14e4c5b2814de5225312394bc316da"
     },
     "ellipsis": {
       "Package": "ellipsis",
-      "Version": "0.3.0",
+      "Version": "0.3.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "7067d90c1c780bfe80c0d497e3d7b49d"
+      "Hash": "bb0eec2fe32e88d9e2836c2f73ea2077"
     },
     "evaluate": {
       "Package": "evaluate",
@@ -250,59 +285,80 @@
     },
     "fansi": {
       "Package": "fansi",
-      "Version": "0.4.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "7fce217eaaf8016e72065e85c73027b5"
-    },
-    "farver": {
-      "Package": "farver",
-      "Version": "2.0.3",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "dad6793a5a1f73c8e91f1a1e3e834b05"
-    },
-    "forcats": {
-      "Package": "forcats",
       "Version": "0.5.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "1cb4279e697650f0bd78cd3601ee7576"
+      "Hash": "d447b40982c576a72b779f0a3b3da227"
     },
-    "fs": {
-      "Package": "fs",
-      "Version": "1.4.1",
+    "farver": {
+      "Package": "farver",
+      "Version": "2.1.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "780713bd2f53156fae001443dcdbdcd5"
+      "Hash": "c98eb5133d9cb9e1622b8691487f11bb"
     },
-    "generics": {
-      "Package": "generics",
-      "Version": "0.0.2",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "b8cff1d1391fd1ad8b65877f4c7f2e53"
-    },
-    "ggplot2": {
-      "Package": "ggplot2",
-      "Version": "3.3.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "911561e07da928345f1ae2d69f97f3ea"
-    },
-    "gh": {
-      "Package": "gh",
+    "fastmap": {
+      "Package": "fastmap",
       "Version": "1.1.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "89ea5998938d1ad55f035c8a86f96b74"
+      "Hash": "77bd60a6157420d4ffa93b27cf6a58b8"
+    },
+    "forcats": {
+      "Package": "forcats",
+      "Version": "0.5.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "81c3244cab67468aac4c60550832655d"
+    },
+    "fs": {
+      "Package": "fs",
+      "Version": "1.5.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "44594a07a42e5f91fac9f93fda6d0109"
+    },
+    "gargle": {
+      "Package": "gargle",
+      "Version": "1.2.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "9d234e6a87a6f8181792de6dc4a00e39"
+    },
+    "generics": {
+      "Package": "generics",
+      "Version": "0.1.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "4d243a9c10b00589889fe32314ffd902"
+    },
+    "gert": {
+      "Package": "gert",
+      "Version": "1.3.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "72b34cde959b806e86cb99fc12d1ba58"
+    },
+    "ggplot2": {
+      "Package": "ggplot2",
+      "Version": "3.3.5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "d7566c471c7b17e095dd023b9ef155ad"
+    },
+    "gh": {
+      "Package": "gh",
+      "Version": "1.3.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "38c2580abbda249bd6afeec00d14f531"
     },
     "git2r": {
       "Package": "git2r",
-      "Version": "0.26.1",
+      "Version": "0.28.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "135db4dbc94ed18f629ff8843a8064b7"
+      "Hash": "f64fd34026f6025de71a4354800e6d79"
     },
     "git2rdata": {
       "Package": "git2rdata",
@@ -311,19 +367,33 @@
       "Repository": "CRAN",
       "Hash": "bf2d93f0e7af2f7b0017d3718efbbaf6"
     },
+    "gitcreds": {
+      "Package": "gitcreds",
+      "Version": "0.1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "f3aefccc1cc50de6338146b62f115de8"
+    },
     "glue": {
       "Package": "glue",
-      "Version": "1.4.0",
+      "Version": "1.4.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "2aefa994e8df5da17dc09afd80f924d5"
+      "Hash": "6efd734b14c6471cfe443345f3e35e29"
     },
-    "googlesheets": {
-      "Package": "googlesheets",
-      "Version": "0.3.0",
+    "googledrive": {
+      "Package": "googledrive",
+      "Version": "2.0.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "270597dd84ec5ef7f59b27b4d28782ee"
+      "Hash": "c3a25adbbfbb03f12e6f88c5fb1f3024"
+    },
+    "googlesheets4": {
+      "Package": "googlesheets4",
+      "Version": "1.0.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "9a6564184dc4a81daea4f1d7ce357c6a"
     },
     "gtable": {
       "Package": "gtable",
@@ -334,45 +404,45 @@
     },
     "haven": {
       "Package": "haven",
-      "Version": "2.2.0",
+      "Version": "2.4.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "e3f662e125e9fdffd1ee4e94baea3451"
+      "Hash": "10bec8a8264f3eb59531e8c4c0303f96"
     },
     "highr": {
       "Package": "highr",
-      "Version": "0.8",
+      "Version": "0.9",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "4dc5bb88961e347a0f4d8aad597cbfac"
+      "Hash": "8eb36c8125038e648e5d111c0d7b2ed4"
     },
     "hms": {
       "Package": "hms",
-      "Version": "0.5.3",
+      "Version": "1.1.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "726671f634529d470545f9fd1a9d1869"
+      "Hash": "e4bf161ccb74a2c1c0e8ac63bbe332b4"
     },
     "htmltools": {
       "Package": "htmltools",
-      "Version": "0.4.0",
+      "Version": "0.5.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "2d7691222f82f41e93f6d30f169bd5e1"
-    },
-    "htmlwidgets": {
-      "Package": "htmlwidgets",
-      "Version": "1.5.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "41bace23583fbc25089edae324de2dc3"
+      "Hash": "526c484233f42522278ab06fb185cb26"
     },
     "httr": {
       "Package": "httr",
-      "Version": "1.4.1",
+      "Version": "1.4.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "7146fea4685b4252ebf478978c75f597"
+      "Hash": "a525aba14184fec243f9eaec62fbed43"
+    },
+    "ids": {
+      "Package": "ids",
+      "Version": "1.0.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "99df65cfef20e525ed38c3d2577f7190"
     },
     "ini": {
       "Package": "ini",
@@ -383,73 +453,66 @@
     },
     "isoband": {
       "Package": "isoband",
-      "Version": "0.2.1",
+      "Version": "0.2.5",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "9b2f7cf1899f583a36d367702ecf49a3"
+      "Hash": "7ab57a6de7f48a8dc84910d1eca42883"
+    },
+    "jquerylib": {
+      "Package": "jquerylib",
+      "Version": "0.1.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "5aab57a3bd297eee1c1d862735972182"
     },
     "jsonlite": {
       "Package": "jsonlite",
-      "Version": "1.6.1",
+      "Version": "1.7.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "84b0ee361e2f78d6b7d670db9471c0c5"
+      "Hash": "98138e0994d41508c7a6b84a0600cfcb"
     },
     "knitr": {
       "Package": "knitr",
-      "Version": "1.28",
+      "Version": "1.33",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "915a6f0134cdbdf016d7778bc80b2eda"
+      "Hash": "0bc1b5da1b0eb07cd4b727e95e9ff0b8"
     },
     "labeling": {
       "Package": "labeling",
-      "Version": "0.3",
+      "Version": "0.4.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "73832978c1de350df58108c745ed0e3e"
-    },
-    "later": {
-      "Package": "later",
-      "Version": "1.0.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "6d927978fc658d24175ce37db635f9e5"
+      "Hash": "3d5108641f47470611a32d0bdf357a72"
     },
     "lattice": {
       "Package": "lattice",
-      "Version": "0.20-41",
+      "Version": "0.20-44",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "fbd9285028b0263d76d18c95ae51a53d"
-    },
-    "lazyeval": {
-      "Package": "lazyeval",
-      "Version": "0.2.2",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "d908914ae53b04d4c0c0fd72ecc35370"
+      "Hash": "f36bf1a849d9106dc2af72e501f9de41"
     },
     "lifecycle": {
       "Package": "lifecycle",
-      "Version": "0.2.0",
+      "Version": "1.0.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "361811f31f71f8a617a9a68bf63f1f42"
+      "Hash": "3471fb65971f1a7b2d4ae7848cf2db8d"
     },
     "lubridate": {
       "Package": "lubridate",
-      "Version": "1.7.8",
+      "Version": "1.7.10",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "6c04c31012c1be39783bebbbfc27b3a3"
+      "Hash": "1ebfdc8a3cfe8fe19184f5481972b092"
     },
     "magrittr": {
       "Package": "magrittr",
-      "Version": "1.5",
+      "Version": "2.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "1bb58822a20301cee84a41678e25d9b7"
+      "Hash": "41287f1ac7d28a92f0a286ed507928d3"
     },
     "markdown": {
       "Package": "markdown",
@@ -460,31 +523,31 @@
     },
     "memoise": {
       "Package": "memoise",
-      "Version": "1.1.0",
+      "Version": "2.0.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "58baa74e4603fcfb9a94401c58c8f9b1"
+      "Hash": "a0bc51650201a56d00a4798523cc91b3"
     },
     "mgcv": {
       "Package": "mgcv",
-      "Version": "1.8-31",
+      "Version": "1.8-36",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "4bb7e0c4f3557583e1e8d3c9ffb8ba5c"
+      "Hash": "93cc747b0e1ad882a4570463c3575c23"
     },
     "mime": {
       "Package": "mime",
-      "Version": "0.9",
+      "Version": "0.11",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "e87a35ec73b157552814869f45a63aa3"
+      "Hash": "8974a907200fc9948d636fe7d85ca9fb"
     },
     "modelr": {
       "Package": "modelr",
-      "Version": "0.1.6",
+      "Version": "0.1.8",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "30a2db10e829133fa0a1e6eaed25bc73"
+      "Hash": "9fd59716311ee82cba83dc2826fc5577"
     },
     "munsell": {
       "Package": "munsell",
@@ -495,38 +558,38 @@
     },
     "nlme": {
       "Package": "nlme",
-      "Version": "3.1-145",
+      "Version": "3.1-152",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "0ed9365684dc39cdd0bb5bd2f316dc67"
+      "Hash": "35de1ce639f20b5e10f7f46260730c65"
     },
     "openssl": {
       "Package": "openssl",
-      "Version": "1.4.1",
+      "Version": "1.4.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "49f7258fd86ebeaea1df24d9ded00478"
+      "Hash": "f4dbc5a47fd93d3415249884d31d6791"
     },
     "pander": {
       "Package": "pander",
-      "Version": "0.6.3",
+      "Version": "0.6.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "121198ce37b5a6b5227edc5a38223da4"
+      "Hash": "0eae8a954e0c51bd356f8c6f0e00e805"
     },
     "pillar": {
       "Package": "pillar",
-      "Version": "1.4.3",
+      "Version": "1.6.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "fa3ed60396b6998d0427c57dab90fba4"
+      "Hash": "43f228eb4b49093d1c8a5c93cae9efe9"
     },
     "pkgbuild": {
       "Package": "pkgbuild",
-      "Version": "1.0.6",
+      "Version": "1.2.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "899835dfe286963471cbdb9591f8f94f"
+      "Hash": "725fcc30222d4d11ec68efb8ff11a9af"
     },
     "pkgconfig": {
       "Package": "pkgconfig",
@@ -537,17 +600,10 @@
     },
     "pkgload": {
       "Package": "pkgload",
-      "Version": "1.0.2",
+      "Version": "1.2.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "5e655fb54cceead0f095f22d7be33da3"
-    },
-    "plogr": {
-      "Package": "plogr",
-      "Version": "0.2.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "09eb987710984fc2905c7129c7d85e65"
+      "Hash": "463642747f81879e6752485aefb831cf"
     },
     "plyr": {
       "Package": "plyr",
@@ -572,10 +628,10 @@
     },
     "processx": {
       "Package": "processx",
-      "Version": "3.4.2",
+      "Version": "3.5.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "20a082f2bde0ffcd8755779fd476a274"
+      "Hash": "0cbca2bc4d16525d009c4dbba156b37c"
     },
     "progress": {
       "Package": "progress",
@@ -584,26 +640,26 @@
       "Repository": "CRAN",
       "Hash": "14dc9f7a3c91ebb14ec5bb9208a07061"
     },
-    "promises": {
-      "Package": "promises",
-      "Version": "1.1.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "efbbe62da4709f7040a380c702bc7103"
-    },
     "ps": {
       "Package": "ps",
-      "Version": "1.3.2",
+      "Version": "1.6.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "98777535b61c57d1749344345e2a4ccd"
+      "Hash": "32620e2001c1dce1af49c49dccbb9420"
     },
     "purrr": {
       "Package": "purrr",
+      "Version": "0.3.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "97def703420c8ab10d8f0e6c72101e02"
+    },
+    "rappdirs": {
+      "Package": "rappdirs",
       "Version": "0.3.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "22aca7d1181718e927d403a8c2d69d62"
+      "Hash": "5e3c5dc0b071b21fa128676560dbe94d"
     },
     "rcmdcheck": {
       "Package": "rcmdcheck",
@@ -614,10 +670,10 @@
     },
     "readr": {
       "Package": "readr",
-      "Version": "1.3.1",
+      "Version": "2.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "af8ab99cd936773a148963905736907b"
+      "Hash": "34807ea4fb5900386ddef904eef8bdb8"
     },
     "readxl": {
       "Package": "readxl",
@@ -633,96 +689,89 @@
       "Repository": "CRAN",
       "Hash": "c66b930d20bb6d858cd18e1cebcfae5c"
     },
-    "remotes": {
-      "Package": "remotes",
-      "Version": "2.1.1",
+    "rematch2": {
+      "Package": "rematch2",
+      "Version": "2.1.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "57c3009534f805f0f6476ffee68483cc"
+      "Hash": "76c9e04c712a05848ae7a23d2f170a40"
+    },
+    "remotes": {
+      "Package": "remotes",
+      "Version": "2.4.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "a85ebb35721573b196317b49ddd2dfe4"
     },
     "renv": {
       "Package": "renv",
-      "Version": "0.9.3",
+      "Version": "0.14.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "c1a367437d8a8a44bec4b9d4974cb20c"
+      "Hash": "30e5eba91b67f7f4d75d31de14bbfbdc"
     },
     "reprex": {
       "Package": "reprex",
-      "Version": "0.3.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "b06bfb3504cc8a4579fd5567646f745b"
-    },
-    "reshape2": {
-      "Package": "reshape2",
-      "Version": "1.4.3",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "15a23ad30f51789188e439599559815c"
-    },
-    "rex": {
-      "Package": "rex",
-      "Version": "1.1.2",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "6d3dbb5d528c8f726861018472bc668c"
-    },
-    "rlang": {
-      "Package": "rlang",
-      "Version": "0.4.5",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "1cc1b38e4db40ea6eb19ab8080bbed3b"
-    },
-    "rmarkdown": {
-      "Package": "rmarkdown",
-      "Version": "2.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "9d1c61d476c448350c482d6664e1b28b"
-    },
-    "roxygen2": {
-      "Package": "roxygen2",
-      "Version": "7.1.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "f173062c04dc8e91d7376d914df6efee"
-    },
-    "rprojroot": {
-      "Package": "rprojroot",
-      "Version": "1.3-2",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "f6a407ae5dd21f6f80a6708bbb6eb3ae"
-    },
-    "rstudioapi": {
-      "Package": "rstudioapi",
-      "Version": "0.11",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "33a5b27a03da82ac4b1d43268f80088a"
-    },
-    "rversions": {
-      "Package": "rversions",
       "Version": "2.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "2aa84e83767ba93ee6415b439fa981d2"
+      "Hash": "911d101becedc0fde495bd910984bdc8"
+    },
+    "rlang": {
+      "Package": "rlang",
+      "Version": "0.4.11",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "515f341d3affe0de9e4a7f762efb0456"
+    },
+    "rmarkdown": {
+      "Package": "rmarkdown",
+      "Version": "2.10",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "1fb097f233ee98968f8e5d0bcd42df6d"
+    },
+    "roxygen2": {
+      "Package": "roxygen2",
+      "Version": "7.1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "fcd94e00cc409b25d07ca50f7bf339f5"
+    },
+    "rprojroot": {
+      "Package": "rprojroot",
+      "Version": "2.0.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "249d8cd1e74a8f6a26194a91b47f21d1"
+    },
+    "rstudioapi": {
+      "Package": "rstudioapi",
+      "Version": "0.13",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "06c85365a03fdaf699966cc1d3cf53ea"
+    },
+    "rversions": {
+      "Package": "rversions",
+      "Version": "2.1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "f88fab00907b312f8b23ec13e2d437cb"
     },
     "rvest": {
       "Package": "rvest",
-      "Version": "0.3.5",
+      "Version": "1.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "6a20c2cdf133ebc7ac45888c9ccc052b"
+      "Hash": "1db38d6f40e3e09527797ca4226a1b5b"
     },
     "scales": {
       "Package": "scales",
-      "Version": "1.1.0",
+      "Version": "1.1.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "a1c68369c629ea3188d0676e37069c65"
+      "Hash": "6f76f71042411426ec8df6c54f34e6dd"
     },
     "selectr": {
       "Package": "selectr",
@@ -740,10 +789,10 @@
     },
     "stringi": {
       "Package": "stringi",
-      "Version": "1.4.6",
+      "Version": "1.7.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "e99d8d656980d2dd416a962ae55aec90"
+      "Hash": "ebaccb577da50829a3bb1b8296f318a5"
     },
     "stringr": {
       "Package": "stringr",
@@ -754,80 +803,108 @@
     },
     "sys": {
       "Package": "sys",
-      "Version": "3.3",
+      "Version": "3.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "507f3116a38d37ad330a038b3be07b66"
+      "Hash": "b227d13e29222b4574486cfcbde077fa"
     },
     "testthat": {
       "Package": "testthat",
-      "Version": "2.3.2",
+      "Version": "3.0.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "0829b987b8961fb07f3b1b64a2fbc495"
+      "Hash": "575216c9946ca70016c3ffb9c31709ba"
     },
     "tibble": {
       "Package": "tibble",
-      "Version": "3.0.0",
+      "Version": "3.1.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "e742bc8d72071ef9aba29f71f132d773"
+      "Hash": "5e8ad5621e5c94b24ec07b88eee13df8"
     },
     "tidyr": {
       "Package": "tidyr",
-      "Version": "1.0.2",
+      "Version": "1.1.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "fb73a010ace00d6c584c2b53a21b969c"
+      "Hash": "450d7dfaedde58e28586b854eeece4fa"
     },
     "tidyselect": {
       "Package": "tidyselect",
-      "Version": "1.0.0",
+      "Version": "1.1.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "7d4b0f1ab542d8cb7a40c593a4de2f36"
+      "Hash": "7243004a708d06d4716717fa1ff5b2fe"
     },
     "tidyverse": {
       "Package": "tidyverse",
-      "Version": "1.3.0",
+      "Version": "1.3.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "bd51be662f359fa99021f3d51e911490"
+      "Hash": "fc4c72b6ae9bb283416bd59a3303bbab"
     },
     "tinytex": {
       "Package": "tinytex",
-      "Version": "0.21",
+      "Version": "0.33",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "02e11a2e5d05f1d5ab19394f19ab2999"
+      "Hash": "6e0ad90ac5669e35d5456cb61b295acb"
+    },
+    "tzdb": {
+      "Package": "tzdb",
+      "Version": "0.1.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "fb2b801053decce71295bb8cb04d438b"
     },
     "usethis": {
       "Package": "usethis",
-      "Version": "1.5.1",
+      "Version": "2.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "30ee6fa315a020d5db6f28adbb7fea83"
+      "Hash": "360e904f9e623286e1a0c6ca0a98c5f6"
     },
     "utf8": {
       "Package": "utf8",
-      "Version": "1.1.4",
+      "Version": "1.2.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "4a5081acfb7b81a572e4384a7aaf2af1"
+      "Hash": "c9c462b759a5cc844ae25b5942654d13"
+    },
+    "uuid": {
+      "Package": "uuid",
+      "Version": "0.1-4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "e4169eb989a5d03ccb6b628cad1b1b50"
     },
     "vctrs": {
       "Package": "vctrs",
-      "Version": "0.2.4",
+      "Version": "0.3.8",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "6c839a149a30cb4ffc70443efa74c197"
+      "Hash": "ecf749a1b39ea72bd9b51b76292261f1"
     },
     "viridisLite": {
       "Package": "viridisLite",
+      "Version": "0.4.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "55e157e2aa88161bdb0754218470d204"
+    },
+    "vroom": {
+      "Package": "vroom",
+      "Version": "1.5.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "1a23013f39e67bb57cbda6f4ddde5470"
+    },
+    "waldo": {
+      "Package": "waldo",
       "Version": "0.3.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "ce4f6271baa94776db692f1cb2055bee"
+      "Hash": "312b264fae22fdba83b7a74187a24da8"
     },
     "whisker": {
       "Package": "whisker",
@@ -838,24 +915,24 @@
     },
     "withr": {
       "Package": "withr",
-      "Version": "2.1.2",
+      "Version": "2.4.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "aa57ed55ff2df4bea697a07df528993d"
+      "Hash": "ad03909b44677f930fa156d47d7a3aeb"
     },
     "xfun": {
       "Package": "xfun",
-      "Version": "0.13",
+      "Version": "0.25",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "3c1eeacd705ff1695db94bfd443b8a84"
+      "Hash": "853d45ffff0a9af1e0af017cd359f75e"
     },
     "xml2": {
       "Package": "xml2",
-      "Version": "1.3.1",
+      "Version": "1.3.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "921dce7c0ec595ed85e77683d3e6c8b6"
+      "Hash": "d4d71a75dd3ea9eb5fa28cc21f9585e2"
     },
     "xopen": {
       "Package": "xopen",
@@ -870,6 +947,13 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "2826c5d9efb0a88f657c7a679c7106db"
+    },
+    "zip": {
+      "Package": "zip",
+      "Version": "2.2.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "c7eef2996ac270a18c2715c997a727c5"
     }
   }
 }

--- a/misc/generate_textdata/renv/.gitignore
+++ b/misc/generate_textdata/renv/.gitignore
@@ -1,3 +1,5 @@
+local/
+lock/
 library/
 python/
 staging/

--- a/misc/generate_textdata/renv/activate.R
+++ b/misc/generate_textdata/renv/activate.R
@@ -2,10 +2,27 @@
 local({
 
   # the requested version of renv
-  version <- "0.9.3"
+  version <- "0.14.0"
+
+  # the project directory
+  project <- getwd()
+
+  # allow environment variable to control activation
+  activate <- Sys.getenv("RENV_ACTIVATE_PROJECT")
+  if (!nzchar(activate)) {
+
+    # don't auto-activate when R CMD INSTALL is running
+    if (nzchar(Sys.getenv("R_INSTALL_PKG")))
+      return(FALSE)
+
+  }
+
+  # bail if activation was explicitly disabled
+  if (tolower(activate) %in% c("false", "f", "0"))
+    return(FALSE)
 
   # avoid recursion
-  if (!is.na(Sys.getenv("RENV_R_INITIALIZING", unset = NA)))
+  if (nzchar(Sys.getenv("RENV_R_INITIALIZING")))
     return(invisible(TRUE))
 
   # signal that we're loading renv during R startup
@@ -33,73 +50,215 @@ local({
 
   }
 
-  # construct path to renv in library
-  libpath <- local({
-
-    root <- Sys.getenv("RENV_PATHS_LIBRARY", unset = "renv/library")
-    prefix <- paste("R", getRversion()[1, 1:2], sep = "-")
-
-    # include SVN revision for development versions of R
-    # (to avoid sharing platform-specific artefacts with released versions of R)
-    devel <-
-      identical(R.version[["status"]],   "Under development (unstable)") ||
-      identical(R.version[["nickname"]], "Unsuffered Consequences")
-
-    if (devel)
-      prefix <- paste(prefix, R.version[["svn rev"]], sep = "-r")
-
-    file.path(root, prefix, R.version$platform)
-
-  })
-
-  # try to load renv from the project library
-  if (requireNamespace("renv", lib.loc = libpath, quietly = TRUE)) {
-
-    # warn if the version of renv loaded does not match
-    loadedversion <- utils::packageDescription("renv", fields = "Version")
-    if (version != loadedversion) {
-
-      # assume four-component versions are from GitHub; three-component
-      # versions are from CRAN
-      components <- strsplit(loadedversion, "[.-]")[[1]]
-      remote <- if (length(components) == 4L)
-        paste("rstudio/renv", loadedversion, sep = "@")
-      else
-        paste("renv", loadedversion, sep = "@")
-
-      fmt <- paste(
-        "renv %1$s was loaded from project library, but renv %2$s is recorded in lockfile.",
-        "Use `renv::record(\"%3$s\")` to record this version in the lockfile.",
-        "Use `renv::restore(packages = \"renv\")` to install renv %2$s into the project library.",
-        sep = "\n"
-      )
-
-      msg <- sprintf(fmt, loadedversion, version, remote)
-      warning(msg, call. = FALSE)
-
-    }
-
-    # load the project
-    return(renv::load())
-
+  # load bootstrap tools   
+  bootstrap <- function(version, library) {
+  
+    # attempt to download renv
+    tarball <- tryCatch(renv_bootstrap_download(version), error = identity)
+    if (inherits(tarball, "error"))
+      stop("failed to download renv ", version)
+  
+    # now attempt to install
+    status <- tryCatch(renv_bootstrap_install(version, tarball, library), error = identity)
+    if (inherits(status, "error"))
+      stop("failed to install renv ", version)
+  
   }
-
-  # failed to find renv locally; we'll try to install from GitHub.
-  # first, set up download options as appropriate (try to use GITHUB_PAT)
-  install_renv <- function() {
-
-    message("Failed to find installation of renv -- attempting to bootstrap...")
-
-    # ensure .Rprofile doesn't get executed
-    rpu <- Sys.getenv("R_PROFILE_USER", unset = NA)
-    Sys.setenv(R_PROFILE_USER = "<NA>")
-    on.exit({
-      if (is.na(rpu))
-        Sys.unsetenv("R_PROFILE_USER")
-      else
-        Sys.setenv(R_PROFILE_USER = rpu)
-    }, add = TRUE)
-
+  
+  renv_bootstrap_tests_running <- function() {
+    getOption("renv.tests.running", default = FALSE)
+  }
+  
+  renv_bootstrap_repos <- function() {
+  
+    # check for repos override
+    repos <- Sys.getenv("RENV_CONFIG_REPOS_OVERRIDE", unset = NA)
+    if (!is.na(repos))
+      return(repos)
+  
+    # if we're testing, re-use the test repositories
+    if (renv_bootstrap_tests_running())
+      return(getOption("renv.tests.repos"))
+  
+    # retrieve current repos
+    repos <- getOption("repos")
+  
+    # ensure @CRAN@ entries are resolved
+    repos[repos == "@CRAN@"] <- getOption(
+      "renv.repos.cran",
+      "https://cloud.r-project.org"
+    )
+  
+    # add in renv.bootstrap.repos if set
+    default <- c(FALLBACK = "https://cloud.r-project.org")
+    extra <- getOption("renv.bootstrap.repos", default = default)
+    repos <- c(repos, extra)
+  
+    # remove duplicates that might've snuck in
+    dupes <- duplicated(repos) | duplicated(names(repos))
+    repos[!dupes]
+  
+  }
+  
+  renv_bootstrap_download <- function(version) {
+  
+    # if the renv version number has 4 components, assume it must
+    # be retrieved via github
+    nv <- numeric_version(version)
+    components <- unclass(nv)[[1]]
+  
+    methods <- if (length(components) == 4L) {
+      list(
+        renv_bootstrap_download_github
+      )
+    } else {
+      list(
+        renv_bootstrap_download_cran_latest,
+        renv_bootstrap_download_cran_archive
+      )
+    }
+  
+    for (method in methods) {
+      path <- tryCatch(method(version), error = identity)
+      if (is.character(path) && file.exists(path))
+        return(path)
+    }
+  
+    stop("failed to download renv ", version)
+  
+  }
+  
+  renv_bootstrap_download_impl <- function(url, destfile) {
+  
+    mode <- "wb"
+  
+    # https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17715
+    fixup <-
+      Sys.info()[["sysname"]] == "Windows" &&
+      substring(url, 1L, 5L) == "file:"
+  
+    if (fixup)
+      mode <- "w+b"
+  
+    utils::download.file(
+      url      = url,
+      destfile = destfile,
+      mode     = mode,
+      quiet    = TRUE
+    )
+  
+  }
+  
+  renv_bootstrap_download_cran_latest <- function(version) {
+  
+    spec <- renv_bootstrap_download_cran_latest_find(version)
+  
+    message("* Downloading renv ", version, " ... ", appendLF = FALSE)
+  
+    type  <- spec$type
+    repos <- spec$repos
+  
+    info <- tryCatch(
+      utils::download.packages(
+        pkgs    = "renv",
+        destdir = tempdir(),
+        repos   = repos,
+        type    = type,
+        quiet   = TRUE
+      ),
+      condition = identity
+    )
+  
+    if (inherits(info, "condition")) {
+      message("FAILED")
+      return(FALSE)
+    }
+  
+    # report success and return
+    message("OK (downloaded ", type, ")")
+    info[1, 2]
+  
+  }
+  
+  renv_bootstrap_download_cran_latest_find <- function(version) {
+  
+    # check whether binaries are supported on this system
+    binary <-
+      getOption("renv.bootstrap.binary", default = TRUE) &&
+      !identical(.Platform$pkgType, "source") &&
+      !identical(getOption("pkgType"), "source") &&
+      Sys.info()[["sysname"]] %in% c("Darwin", "Windows")
+  
+    types <- c(if (binary) "binary", "source")
+  
+    # iterate over types + repositories
+    for (type in types) {
+      for (repos in renv_bootstrap_repos()) {
+  
+        # retrieve package database
+        db <- tryCatch(
+          as.data.frame(
+            utils::available.packages(type = type, repos = repos),
+            stringsAsFactors = FALSE
+          ),
+          error = identity
+        )
+  
+        if (inherits(db, "error"))
+          next
+  
+        # check for compatible entry
+        entry <- db[db$Package %in% "renv" & db$Version %in% version, ]
+        if (nrow(entry) == 0)
+          next
+  
+        # found it; return spec to caller
+        spec <- list(entry = entry, type = type, repos = repos)
+        return(spec)
+  
+      }
+    }
+  
+    # if we got here, we failed to find renv
+    fmt <- "renv %s is not available from your declared package repositories"
+    stop(sprintf(fmt, version))
+  
+  }
+  
+  renv_bootstrap_download_cran_archive <- function(version) {
+  
+    name <- sprintf("renv_%s.tar.gz", version)
+    repos <- renv_bootstrap_repos()
+    urls <- file.path(repos, "src/contrib/Archive/renv", name)
+    destfile <- file.path(tempdir(), name)
+  
+    message("* Downloading renv ", version, " ... ", appendLF = FALSE)
+  
+    for (url in urls) {
+  
+      status <- tryCatch(
+        renv_bootstrap_download_impl(url, destfile),
+        condition = identity
+      )
+  
+      if (identical(status, 0L)) {
+        message("OK")
+        return(destfile)
+      }
+  
+    }
+  
+    message("FAILED")
+    return(FALSE)
+  
+  }
+  
+  renv_bootstrap_download_github <- function(version) {
+  
+    enabled <- Sys.getenv("RENV_BOOTSTRAP_FROM_GITHUB", unset = "TRUE")
+    if (!identical(enabled, "TRUE"))
+      return(FALSE)
+  
     # prepare download options
     pat <- Sys.getenv("GITHUB_PAT")
     if (nzchar(Sys.which("curl")) && nzchar(pat)) {
@@ -115,62 +274,386 @@ local({
       options(download.file.method = "wget", download.file.extra = extra)
       on.exit(do.call(base::options, saved), add = TRUE)
     }
-
-    # fix up repos
-    repos <- getOption("repos")
-    on.exit(options(repos = repos), add = TRUE)
-    repos[repos == "@CRAN@"] <- "https://cloud.r-project.org"
-    options(repos = repos)
-
-    # check for renv on CRAN matching this version
-    db <- as.data.frame(available.packages(), stringsAsFactors = FALSE)
-    if ("renv" %in% rownames(db)) {
-      entry <- db["renv", ]
-      if (identical(entry$Version, version)) {
-        message("* Installing renv ", version, " ... ", appendLF = FALSE)
-        dir.create(libpath, showWarnings = FALSE, recursive = TRUE)
-        utils::install.packages("renv", lib = libpath, quiet = TRUE)
-        message("Done!")
-        return(TRUE)
-      }
+  
+    message("* Downloading renv ", version, " from GitHub ... ", appendLF = FALSE)
+  
+    url <- file.path("https://api.github.com/repos/rstudio/renv/tarball", version)
+    name <- sprintf("renv_%s.tar.gz", version)
+    destfile <- file.path(tempdir(), name)
+  
+    status <- tryCatch(
+      renv_bootstrap_download_impl(url, destfile),
+      condition = identity
+    )
+  
+    if (!identical(status, 0L)) {
+      message("FAILED")
+      return(FALSE)
     }
-
-    # try to download renv
-    message("* Downloading renv ", version, " ... ", appendLF = FALSE)
-    prefix <- "https://api.github.com"
-    url <- file.path(prefix, "repos/rstudio/renv/tarball", version)
-    destfile <- tempfile("renv-", fileext = ".tar.gz")
-    on.exit(unlink(destfile), add = TRUE)
-    utils::download.file(url, destfile = destfile, mode = "wb", quiet = TRUE)
-    message("Done!")
-
+  
+    message("OK")
+    return(destfile)
+  
+  }
+  
+  renv_bootstrap_install <- function(version, tarball, library) {
+  
     # attempt to install it into project library
     message("* Installing renv ", version, " ... ", appendLF = FALSE)
-    dir.create(libpath, showWarnings = FALSE, recursive = TRUE)
-
+    dir.create(library, showWarnings = FALSE, recursive = TRUE)
+  
     # invoke using system2 so we can capture and report output
     bin <- R.home("bin")
     exe <- if (Sys.info()[["sysname"]] == "Windows") "R.exe" else "R"
     r <- file.path(bin, exe)
-    args <- c("--vanilla", "CMD", "INSTALL", "-l", shQuote(libpath), shQuote(destfile))
+    args <- c("--vanilla", "CMD", "INSTALL", "-l", shQuote(library), shQuote(tarball))
     output <- system2(r, args, stdout = TRUE, stderr = TRUE)
     message("Done!")
-
+  
     # check for successful install
     status <- attr(output, "status")
     if (is.numeric(status) && !identical(status, 0L)) {
-      text <- c("Error installing renv", "=====================", output)
+      header <- "Error installing renv:"
+      lines <- paste(rep.int("=", nchar(header)), collapse = "")
+      text <- c(header, lines, output)
       writeLines(text, con = stderr())
     }
-
-
+  
+    status
+  
+  }
+  
+  renv_bootstrap_platform_prefix <- function() {
+  
+    # construct version prefix
+    version <- paste(R.version$major, R.version$minor, sep = ".")
+    prefix <- paste("R", numeric_version(version)[1, 1:2], sep = "-")
+  
+    # include SVN revision for development versions of R
+    # (to avoid sharing platform-specific artefacts with released versions of R)
+    devel <-
+      identical(R.version[["status"]],   "Under development (unstable)") ||
+      identical(R.version[["nickname"]], "Unsuffered Consequences")
+  
+    if (devel)
+      prefix <- paste(prefix, R.version[["svn rev"]], sep = "-r")
+  
+    # build list of path components
+    components <- c(prefix, R.version$platform)
+  
+    # include prefix if provided by user
+    prefix <- renv_bootstrap_platform_prefix_impl()
+    if (!is.na(prefix) && nzchar(prefix))
+      components <- c(prefix, components)
+  
+    # build prefix
+    paste(components, collapse = "/")
+  
+  }
+  
+  renv_bootstrap_platform_prefix_impl <- function() {
+  
+    # if an explicit prefix has been supplied, use it
+    prefix <- Sys.getenv("RENV_PATHS_PREFIX", unset = NA)
+    if (!is.na(prefix))
+      return(prefix)
+  
+    # if the user has requested an automatic prefix, generate it
+    auto <- Sys.getenv("RENV_PATHS_PREFIX_AUTO", unset = NA)
+    if (auto %in% c("TRUE", "True", "true", "1"))
+      return(renv_bootstrap_platform_prefix_auto())
+  
+    # empty string on failure
+    ""
+  
+  }
+  
+  renv_bootstrap_platform_prefix_auto <- function() {
+  
+    prefix <- tryCatch(renv_bootstrap_platform_os(), error = identity)
+    if (inherits(prefix, "error") || prefix %in% "unknown") {
+  
+      msg <- paste(
+        "failed to infer current operating system",
+        "please file a bug report at https://github.com/rstudio/renv/issues",
+        sep = "; "
+      )
+  
+      warning(msg)
+  
+    }
+  
+    prefix
+  
+  }
+  
+  renv_bootstrap_platform_os <- function() {
+  
+    sysinfo <- Sys.info()
+    sysname <- sysinfo[["sysname"]]
+  
+    # handle Windows + macOS up front
+    if (sysname == "Windows")
+      return("windows")
+    else if (sysname == "Darwin")
+      return("macos")
+  
+    # check for os-release files
+    for (file in c("/etc/os-release", "/usr/lib/os-release"))
+      if (file.exists(file))
+        return(renv_bootstrap_platform_os_via_os_release(file, sysinfo))
+  
+    # check for redhat-release files
+    if (file.exists("/etc/redhat-release"))
+      return(renv_bootstrap_platform_os_via_redhat_release())
+  
+    "unknown"
+  
+  }
+  
+  renv_bootstrap_platform_os_via_os_release <- function(file, sysinfo) {
+  
+    # read /etc/os-release
+    release <- utils::read.table(
+      file             = file,
+      sep              = "=",
+      quote            = c("\"", "'"),
+      col.names        = c("Key", "Value"),
+      comment.char     = "#",
+      stringsAsFactors = FALSE
+    )
+  
+    vars <- as.list(release$Value)
+    names(vars) <- release$Key
+  
+    # get os name
+    os <- tolower(sysinfo[["sysname"]])
+  
+    # read id
+    id <- "unknown"
+    for (field in c("ID", "ID_LIKE")) {
+      if (field %in% names(vars) && nzchar(vars[[field]])) {
+        id <- vars[[field]]
+        break
+      }
+    }
+  
+    # read version
+    version <- "unknown"
+    for (field in c("UBUNTU_CODENAME", "VERSION_CODENAME", "VERSION_ID", "BUILD_ID")) {
+      if (field %in% names(vars) && nzchar(vars[[field]])) {
+        version <- vars[[field]]
+        break
+      }
+    }
+  
+    # join together
+    paste(c(os, id, version), collapse = "-")
+  
+  }
+  
+  renv_bootstrap_platform_os_via_redhat_release <- function() {
+  
+    # read /etc/redhat-release
+    contents <- readLines("/etc/redhat-release", warn = FALSE)
+  
+    # infer id
+    id <- if (grepl("centos", contents, ignore.case = TRUE))
+      "centos"
+    else if (grepl("redhat", contents, ignore.case = TRUE))
+      "redhat"
+    else
+      "unknown"
+  
+    # try to find a version component (very hacky)
+    version <- "unknown"
+  
+    parts <- strsplit(contents, "[[:space:]]")[[1L]]
+    for (part in parts) {
+  
+      nv <- tryCatch(numeric_version(part), error = identity)
+      if (inherits(nv, "error"))
+        next
+  
+      version <- nv[1, 1]
+      break
+  
+    }
+  
+    paste(c("linux", id, version), collapse = "-")
+  
+  }
+  
+  renv_bootstrap_library_root_name <- function(project) {
+  
+    # use project name as-is if requested
+    asis <- Sys.getenv("RENV_PATHS_LIBRARY_ROOT_ASIS", unset = "FALSE")
+    if (asis)
+      return(basename(project))
+  
+    # otherwise, disambiguate based on project's path
+    id <- substring(renv_bootstrap_hash_text(project), 1L, 8L)
+    paste(basename(project), id, sep = "-")
+  
+  }
+  
+  renv_bootstrap_library_root <- function(project) {
+  
+    path <- Sys.getenv("RENV_PATHS_LIBRARY", unset = NA)
+    if (!is.na(path))
+      return(path)
+  
+    path <- Sys.getenv("RENV_PATHS_LIBRARY_ROOT", unset = NA)
+    if (!is.na(path)) {
+      name <- renv_bootstrap_library_root_name(project)
+      return(file.path(path, name))
+    }
+  
+    prefix <- renv_bootstrap_profile_prefix()
+    paste(c(project, prefix, "renv/library"), collapse = "/")
+  
+  }
+  
+  renv_bootstrap_validate_version <- function(version) {
+  
+    loadedversion <- utils::packageDescription("renv", fields = "Version")
+    if (version == loadedversion)
+      return(TRUE)
+  
+    # assume four-component versions are from GitHub; three-component
+    # versions are from CRAN
+    components <- strsplit(loadedversion, "[.-]")[[1]]
+    remote <- if (length(components) == 4L)
+      paste("rstudio/renv", loadedversion, sep = "@")
+    else
+      paste("renv", loadedversion, sep = "@")
+  
+    fmt <- paste(
+      "renv %1$s was loaded from project library, but this project is configured to use renv %2$s.",
+      "Use `renv::record(\"%3$s\")` to record renv %1$s in the lockfile.",
+      "Use `renv::restore(packages = \"renv\")` to install renv %2$s into the project library.",
+      sep = "\n"
+    )
+  
+    msg <- sprintf(fmt, loadedversion, version, remote)
+    warning(msg, call. = FALSE)
+  
+    FALSE
+  
+  }
+  
+  renv_bootstrap_hash_text <- function(text) {
+  
+    hashfile <- tempfile("renv-hash-")
+    on.exit(unlink(hashfile), add = TRUE)
+  
+    writeLines(text, con = hashfile)
+    tools::md5sum(hashfile)
+  
+  }
+  
+  renv_bootstrap_load <- function(project, libpath, version) {
+  
+    # try to load renv from the project library
+    if (!requireNamespace("renv", lib.loc = libpath, quietly = TRUE))
+      return(FALSE)
+  
+    # warn if the version of renv loaded does not match
+    renv_bootstrap_validate_version(version)
+  
+    # load the project
+    renv::load(project)
+  
+    TRUE
+  
+  }
+  
+  renv_bootstrap_profile_load <- function(project) {
+  
+    # if RENV_PROFILE is already set, just use that
+    profile <- Sys.getenv("RENV_PROFILE", unset = NA)
+    if (!is.na(profile) && nzchar(profile))
+      return(profile)
+  
+    # check for a profile file (nothing to do if it doesn't exist)
+    path <- file.path(project, "renv/local/profile")
+    if (!file.exists(path))
+      return(NULL)
+  
+    # read the profile, and set it if it exists
+    contents <- readLines(path, warn = FALSE)
+    if (length(contents) == 0L)
+      return(NULL)
+  
+    # set RENV_PROFILE
+    profile <- contents[[1L]]
+    if (nzchar(profile))
+      Sys.setenv(RENV_PROFILE = profile)
+  
+    profile
+  
+  }
+  
+  renv_bootstrap_profile_prefix <- function() {
+    profile <- renv_bootstrap_profile_get()
+    if (!is.null(profile))
+      return(file.path("renv/profiles", profile))
+  }
+  
+  renv_bootstrap_profile_get <- function() {
+    profile <- Sys.getenv("RENV_PROFILE", unset = "")
+    renv_bootstrap_profile_normalize(profile)
+  }
+  
+  renv_bootstrap_profile_set <- function(profile) {
+    profile <- renv_bootstrap_profile_normalize(profile)
+    if (is.null(profile))
+      Sys.unsetenv("RENV_PROFILE")
+    else
+      Sys.setenv(RENV_PROFILE = profile)
+  }
+  
+  renv_bootstrap_profile_normalize <- function(profile) {
+  
+    if (is.null(profile) || profile %in% c("", "default"))
+      return(NULL)
+  
+    profile
+  
   }
 
-  try(install_renv())
+  # load the renv profile, if any
+  renv_bootstrap_profile_load(project)
+
+  # construct path to library root
+  root <- renv_bootstrap_library_root(project)
+
+  # construct library prefix for platform
+  prefix <- renv_bootstrap_platform_prefix()
+
+  # construct full libpath
+  libpath <- file.path(root, prefix)
+
+  # attempt to load
+  if (renv_bootstrap_load(project, libpath, version))
+    return(TRUE)
+
+  # load failed; inform user we're about to bootstrap
+  prefix <- paste("# Bootstrapping renv", version)
+  postfix <- paste(rep.int("-", 77L - nchar(prefix)), collapse = "")
+  header <- paste(prefix, postfix)
+  message(header)
+
+  # perform bootstrap
+  bootstrap(version, libpath)
+
+  # exit early if we're just testing bootstrap
+  if (!is.na(Sys.getenv("RENV_BOOTSTRAP_INSTALL_ONLY", unset = NA)))
+    return(TRUE)
 
   # try again to load
   if (requireNamespace("renv", lib.loc = libpath, quietly = TRUE)) {
-    message("Successfully installed and loaded renv ", version, ".")
+    message("* Successfully installed and loaded renv ", version, ".")
     return(renv::load())
   }
 

--- a/misc/generate_textdata/renv/settings.dcf
+++ b/misc/generate_textdata/renv/settings.dcf
@@ -1,6 +1,6 @@
 external.libraries:
 ignored.packages:
 package.dependency.fields: Imports, Depends, LinkingTo
-snapshot.type: packrat
+snapshot.type: implicit
 use.cache: TRUE
 vcs.ignore.library: TRUE


### PR DESCRIPTION
Because the `googlesheets` package had stopped working, the code has been migrated to `googlesheets4`. Also, all gsheet-IDs are now defined in one chunk in `index.Rmd`.

Meanwhile, two data changes have taken place due to updates in gsheets:

- a few English type name updates by S. De Saeger
- scheme `HQ2190` has been split into two schemes

@ToonHub can you update below code that you made earlier? By making a join between `attribute_1` and `code`, it has been assumed that `attribute_1` always refers to a type, the name of which is used to automatically generate scheme names in `namelist`. However, currently `attribute_1` in the `schemes_MHQ` object contains a value `2190_terr` as `attribute_1`.

https://github.com/inbo/n2khab/blob/86bd48ca4a2b6ad4386f01efd1e61b2a97e6dacc/misc/generate_textdata/30_schemes_and_scheme_types.Rmd#L569-L584

This currently leads to an erroneous last line in `namelist.tsv`:

https://github.com/inbo/n2khab/blob/googlesheets4_hq2190/inst/textdata/namelist.tsv#L612

In case you consider `attribute_1` to no longer always be a type name, please also update this in the documentation of the `schemes` data source:

https://github.com/inbo/n2khab/blob/86bd48ca4a2b6ad4386f01efd1e61b2a97e6dacc/R/textdata.R#L244-L253

Preferably do these changes in a new pull request that branches from `googlesheets4_hq2190` and that targets `googlesheets4_hq2190`, then you can add me as reviewer for that part.

Assuming that you'll need to do some steps interactively, or by compiling the bookdown yourself (in the **generate_textdata** project): `renv`'s R version is now upgraded to 4.1.1 and the package versions are more recent (except `git2rdata`, which has been frozen at 0.2.1 in order to avoid re-sorting many rows). Anyway the `renv::restore()` line in `index.Rmd` should do its work.