### PR TITLE
types: change value of groundw_dep for type 91F0 to GD2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,8 +4,9 @@
 
 - Function `read_shallowgroundwater()` to return the `shallowgroundwater` data source (#156).
   - x
-- Reference lists `schemes`, `scheme_types`, `namelist` were updated (#150, #151, #154):
+- Reference lists `types`, `schemes`, `scheme_types`, `namelist` were updated (#150, #151, #154, #158):
   - a few type name updates (thanks S. De Saeger);
+  - updated value of `groundw_dep` for type `91F0`;
   - environmental pressures `ep_07.2` and `ep_07.4` received updated (Dutch) explanations;
   - scheme `HQ2190` has been replaced by two schemes `HQ2190_terr` and `HQ2190_aq`;
   - typegroups were defined for scheme `GW_05.1_aq` (with contributions from L. Denys & A. Leyssen).

--- a/inst/textdata/types.tsv
+++ b/inst/textdata/types.tsv
@@ -105,7 +105,7 @@ rbbms	main_type	rbbms	BMF	HC2	GD2	FD0	NA	NA	NA
 91E0_vm	subtype	91E0	FS	HC2	GD2	FD0	NA	NA	NA
 91E0_vn	subtype	91E0	FS	HC2	GD2	FD1	NA	NA	NA
 91E0_vo	subtype	91E0	FS	HC2	GD2	FD0	NA	NA	NA
-91F0	main_type	91F0	FS	HC2	GD1	FD2	NA	NA	NA
+91F0	main_type	91F0	FS	HC2	GD2	FD2	NA	NA	NA
 rbbppm	main_type	rbbppm	FS	HC12	GD1	FD0	NA	NA	NA
 rbbsf	main_type	rbbsf	FS	HC2	GD2	FD1	NA	NA	NA
 rbbso	main_type	rbbso	FS	HC2	GD2	FD0	NA	NA	NA

--- a/inst/textdata/types.yml
+++ b/inst/textdata/types.yml
@@ -6,7 +6,7 @@
   - typeclass
   - type
   hash: 3716361494fa7d0742afaf7cb987f8ad91e0fb52
-  data_hash: 460e412331777e43036efa37a72c49f3fdcf2e50
+  data_hash: 4992ac786610fc07fdee05a9f7cc83a62c51cff2
 type:
   class: factor
   labels:


### PR DESCRIPTION
Since there's only one Flemish location of `91F0`, it's more consistent to choose
either `GD0` or `GD2` instead of `GD1`.
`GD2` has been chosen because groundwater dependency is plausible at this site,
although actually unknown.
Groundwater dependency is defined as 'sensitive to desiccation through groundwater'.