### PR TITLE
read_watersurfaces(): make fix_geom handling a bit more efficient

### DIFF
--- a/R/read_habitatdata.R
+++ b/R/read_habitatdata.R
@@ -679,6 +679,8 @@ read_watersurfaces <-
       if (n_invalid > 0) {
         watersurfaces <- st_make_valid(watersurfaces)
         message("Fixed ", n_invalid, " invalid or corrupt geometries.")
+      } else {
+        message("No invalid or corrupt geometries found.")
       }
     }
 

--- a/R/read_habitatdata.R
+++ b/R/read_habitatdata.R
@@ -674,9 +674,8 @@ read_watersurfaces <-
     }
 
     if (fix_geom) {
-      n_invalid <- sum(
-        !st_is_valid(watersurfaces) | is.na(st_is_valid(watersurfaces))
-      )
+      validities <- st_is_valid(watersurfaces)
+      n_invalid <- sum(!validities | is.na(validities))
       if (n_invalid > 0) {
         watersurfaces <- st_make_valid(watersurfaces)
         message("Fixed ", n_invalid, " invalid or corrupt geometries.")


### PR DESCRIPTION
@cecileherr pointed out in #184 that applying the optional count of invalid polygons in `read_habitatmap(fix_geom = TRUE)` is very slow. It was copied from `read_watersurfaces()`, where timing was still acceptable.

It seems that I calculated the polygon validity twice. Reducing this to a single calculation already gives some speedup, even though this will not be acceptable yet in case of `read_habitatmap()`.

```r
> # using n2khab 0.10.1
>
> system.time(n2khab::read_watersurfaces(fix_geom = TRUE) |> invisible())
Fixed 9 invalid or corrupt geometries.
   user  system elapsed 
 21.675   1.443   7.712 
> system.time(n2khab::read_watersurfaces(fix_geom = TRUE) |> invisible())
Fixed 9 invalid or corrupt geometries.
   user  system elapsed 
  6.377   0.031   6.408 
>
> # using n2khab@876df05
>
> devtools::load_all(".")
ℹ Loading n2khab
Attaching n2khab 0.10.1.9000.
Will use sf 1.0-16.
Will use terra 1.7-78.
> system.time(read_watersurfaces(fix_geom = TRUE) |> invisible())
Fixed 9 invalid or corrupt geometries.
   user  system elapsed 
  5.454   0.034   5.488 
> system.time(read_watersurfaces(fix_geom = TRUE) |> invisible())
Fixed 9 invalid or corrupt geometries.
   user  system elapsed 
  5.147   0.010   5.157 
> system.time(read_watersurfaces(fix_geom = TRUE) |> invisible())
Fixed 9 invalid or corrupt geometries.
   user  system elapsed 
  5.143   0.051   5.193 
> system.time(read_watersurfaces() |> invisible())
   user  system elapsed 
  1.188   0.012   1.203 

Restarting R session...

> # using n2khab 0.10.1
>
> system.time(n2khab::read_watersurfaces(fix_geom = TRUE) |> invisible())
Fixed 9 invalid or corrupt geometries.
   user  system elapsed 
  8.179   0.135   8.298 
```