### PR TITLE
n2khab_options(): fix bug in case both options are set

### DIFF
--- a/R/options.R
+++ b/R/options.R
@@ -77,7 +77,7 @@ n2khab_options <- function() {
     ),
     "n2khab_use_raster",
     tryCatch(
-      n2khab_using_raster(),
+      as.character(n2khab_using_raster()),
       error = function(e) {
         message(as.character(e))
         NA


### PR DESCRIPTION
The value column of the tibble cannot hold different classes.

So converting those other than character to character.