### PR TITLE
Update read_habitatdat for use with habitatmap 2024 v99 interim

### DIFF
--- a/R/read_habitatdata.R
+++ b/R/read_habitatdata.R
@@ -1424,9 +1424,9 @@ read_habitatmap_terr <-
       habmap_terr_types <-
         habmap_terr_types %>%
         relocate(
-          .data$polygon_id,
-          .data$type,
-          .data$certain
+          "polygon_id",
+          "type",
+          "certain"
         )
     }
 

--- a/R/read_habitatdata.R
+++ b/R/read_habitatdata.R
@@ -367,7 +367,8 @@ read_watersurfaces_hab <-
              "watersurfaces_hab_v4",
              "watersurfaces_hab_v3",
              "watersurfaces_hab_v2",
-             "watersurfaces_hab_v1"
+             "watersurfaces_hab_v1",
+             "watersurfaces_hab_v6.1_interim"
            )) {
     version <- match.arg(version)
 

--- a/R/read_habitatdata.R
+++ b/R/read_habitatdata.R
@@ -80,6 +80,8 @@
 #' starting from the working directory.
 #' @param version Version ID of the data source.
 #' Defaults to the latest available version defined by the package.
+#' Versions with the 'interim' suffix are designed to be used within the Research
+#' Institute for Nature and Forest (INBO) only.
 #'
 #' @return
 #' A list of two objects:
@@ -163,7 +165,8 @@ read_habitatmap_stdized <-
              "habitatmap_stdized_2023_v1",
              "habitatmap_stdized_2020_v1",
              "habitatmap_stdized_2018_v2",
-             "habitatmap_stdized_2018_v1"
+             "habitatmap_stdized_2018_v1",
+             "habitatmap_stdized_2025_interim"
            )) {
     version <- match.arg(version)
 

--- a/R/read_habitatdata.R
+++ b/R/read_habitatdata.R
@@ -166,7 +166,7 @@ read_habitatmap_stdized <-
              "habitatmap_stdized_2020_v1",
              "habitatmap_stdized_2018_v2",
              "habitatmap_stdized_2018_v1",
-             "habitatmap_stdized_2025_interim"
+             "habitatmap_stdized_2024_v99_interim"
            )) {
     version <- match.arg(version)
 
@@ -1349,7 +1349,7 @@ read_habitatmap_terr <-
              "habitatmap_terr_2020_v1",
              "habitatmap_terr_2018_v2",
              "habitatmap_terr_2018_v1",
-             "habitatmap_terr_2025_interim"
+             "habitatmap_terr_2024_v99_interim"
            )) {
     assert_that(is.flag(keep_aq_types), noNA(keep_aq_types))
     assert_that(is.flag(drop_7220), noNA(drop_7220))

--- a/R/read_habitatdata.R
+++ b/R/read_habitatdata.R
@@ -1347,7 +1347,8 @@ read_habitatmap_terr <-
              "habitatmap_terr_2020_v2",
              "habitatmap_terr_2020_v1",
              "habitatmap_terr_2018_v2",
-             "habitatmap_terr_2018_v1"
+             "habitatmap_terr_2018_v1",
+             "habitatmap_terr_2025_interim"
            )) {
     assert_that(is.flag(keep_aq_types), noNA(keep_aq_types))
     assert_that(is.flag(drop_7220), noNA(drop_7220))

--- a/R/read_habitatdata.R
+++ b/R/read_habitatdata.R
@@ -213,9 +213,9 @@ read_habitatmap_stdized <-
       habmap_types <-
         habmap_types %>%
         relocate(
-          .data$polygon_id,
-          .data$type,
-          .data$certain
+          "polygon_id",
+          "type",
+          "certain"
         )
     }
 

--- a/man/read_habitatmap.Rd
+++ b/man/read_habitatmap.Rd
@@ -35,7 +35,9 @@ geometries (with GEOS as backend).
 Defaults to \code{FALSE}.}
 
 \item{version}{Version ID of the data source.
-Defaults to the latest available version defined by the package.}
+Defaults to the latest available version defined by the package.
+Versions with the 'interim' suffix are designed to be used within the Research
+Institute for Nature and Forest (INBO) only.}
 }
 \value{
 A Simple feature collection of

--- a/man/read_habitatmap_stdized.Rd
+++ b/man/read_habitatmap_stdized.Rd
@@ -10,7 +10,7 @@ read_habitatmap_stdized(
     "20_processed/habitatmap_stdized/habitatmap_stdized.gpkg"),
   version = c("habitatmap_stdized_2023_v1", "habitatmap_stdized_2020_v1",
     "habitatmap_stdized_2018_v2", "habitatmap_stdized_2018_v1",
-    "habitatmap_stdized_2025_interim")
+    "habitatmap_stdized_2024_v99_interim")
 )
 }
 \arguments{

--- a/man/read_habitatmap_stdized.Rd
+++ b/man/read_habitatmap_stdized.Rd
@@ -9,7 +9,8 @@ read_habitatmap_stdized(
   file = file.path(locate_n2khab_data(),
     "20_processed/habitatmap_stdized/habitatmap_stdized.gpkg"),
   version = c("habitatmap_stdized_2023_v1", "habitatmap_stdized_2020_v1",
-    "habitatmap_stdized_2018_v2", "habitatmap_stdized_2018_v1")
+    "habitatmap_stdized_2018_v2", "habitatmap_stdized_2018_v1",
+    "habitatmap_stdized_2025_interim")
 )
 }
 \arguments{
@@ -21,7 +22,9 @@ sequentially climbing up 0 to 10 levels in the file system hierarchy,
 starting from the working directory.}
 
 \item{version}{Version ID of the data source.
-Defaults to the latest available version defined by the package.}
+Defaults to the latest available version defined by the package.
+Versions with the 'interim' suffix are designed to be used within the Research
+Institute for Nature and Forest (INBO) only.}
 }
 \value{
 A list of two objects:

--- a/man/read_habitatmap_terr.Rd
+++ b/man/read_habitatmap_terr.Rd
@@ -11,7 +11,8 @@ read_habitatmap_terr(
   keep_aq_types = TRUE,
   drop_7220 = TRUE,
   version = c("habitatmap_terr_2023_v1", "habitatmap_terr_2020_v2",
-    "habitatmap_terr_2020_v1", "habitatmap_terr_2018_v2", "habitatmap_terr_2018_v1")
+    "habitatmap_terr_2020_v1", "habitatmap_terr_2018_v2", "habitatmap_terr_2018_v1",
+    "habitatmap_terr_2025_interim")
 )
 }
 \arguments{

--- a/man/read_habitatmap_terr.Rd
+++ b/man/read_habitatmap_terr.Rd
@@ -12,7 +12,7 @@ read_habitatmap_terr(
   drop_7220 = TRUE,
   version = c("habitatmap_terr_2023_v1", "habitatmap_terr_2020_v2",
     "habitatmap_terr_2020_v1", "habitatmap_terr_2018_v2", "habitatmap_terr_2018_v1",
-    "habitatmap_terr_2025_interim")
+    "habitatmap_terr_2024_v99_interim")
 )
 }
 \arguments{

--- a/man/read_habitatmap_terr.Rd
+++ b/man/read_habitatmap_terr.Rd
@@ -44,7 +44,9 @@ to use the \code{habitatsprings} data source and not
 \code{\link[=read_habitatsprings]{read_habitatsprings()}}.}
 
 \item{version}{Version ID of the data source.
-Defaults to the latest available version defined by the package.}
+Defaults to the latest available version defined by the package.
+Versions with the 'interim' suffix are designed to be used within the Research
+Institute for Nature and Forest (INBO) only.}
 }
 \value{
 A list of two objects:

--- a/man/read_habitatquarries.Rd
+++ b/man/read_habitatquarries.Rd
@@ -31,7 +31,9 @@ references (element \code{extra_references}).}
 being printed to the console, formatted for usage in a BibTeX file (\verb{*.bib}).}
 
 \item{version}{Version ID of the data source.
-Defaults to the latest available version defined by the package.}
+Defaults to the latest available version defined by the package.
+Versions with the 'interim' suffix are designed to be used within the Research
+Institute for Nature and Forest (INBO) only.}
 }
 \value{
 Depending on the arguments, one of:

--- a/man/read_habitatsprings.Rd
+++ b/man/read_habitatsprings.Rd
@@ -31,7 +31,9 @@ centroid, their area attribute is summed (if all values are known)
 and for other attributes the maximum value is returned.}
 
 \item{version}{Version ID of the data source.
-Defaults to the latest available version defined by the package.}
+Defaults to the latest available version defined by the package.
+Versions with the 'interim' suffix are designed to be used within the Research
+Institute for Nature and Forest (INBO) only.}
 }
 \value{
 A Simple feature collection of

--- a/man/read_raster_runif.Rd
+++ b/man/read_raster_runif.Rd
@@ -18,7 +18,9 @@ sequentially climbing up 0 to 10 levels in the file system hierarchy,
 starting from the working directory.}
 
 \item{version}{Version ID of the data source.
-Defaults to the latest available version defined by the package.}
+Defaults to the latest available version defined by the package.
+Versions with the 'interim' suffix are designed to be used within the Research
+Institute for Nature and Forest (INBO) only.}
 }
 \value{
 A SpatRaster.

--- a/man/read_watercourse_100mseg.Rd
+++ b/man/read_watercourse_100mseg.Rd
@@ -26,7 +26,9 @@ If set, either the \code{lines} or the \code{points} object will be
 returned, respectively.}
 
 \item{version}{Version ID of the data source.
-Defaults to the latest available version defined by the package.}
+Defaults to the latest available version defined by the package.
+Versions with the 'interim' suffix are designed to be used within the Research
+Institute for Nature and Forest (INBO) only.}
 }
 \value{
 By default, a list of two \code{sf} objects (see 'Description').

--- a/man/read_watersurfaces.Rd
+++ b/man/read_watersurfaces.Rd
@@ -39,7 +39,9 @@ geometries (with GEOS as backend).
 Defaults to \code{FALSE}.}
 
 \item{version}{Version ID of the data source.
-Defaults to the latest available version defined by the package.}
+Defaults to the latest available version defined by the package.
+Versions with the 'interim' suffix are designed to be used within the Research
+Institute for Nature and Forest (INBO) only.}
 }
 \value{
 A Simple feature collection of

--- a/man/read_watersurfaces_hab.Rd
+++ b/man/read_watersurfaces_hab.Rd
@@ -25,7 +25,9 @@ starting from the working directory.}
 applies to type 3130. When the subtype is missing for 3130, we interpret it as 3130_aom.}
 
 \item{version}{Version ID of the data source.
-Defaults to the latest available version defined by the package.}
+Defaults to the latest available version defined by the package.
+Versions with the 'interim' suffix are designed to be used within the Research
+Institute for Nature and Forest (INBO) only.}
 }
 \value{
 A list of two objects:

--- a/man/read_watersurfaces_hab.Rd
+++ b/man/read_watersurfaces_hab.Rd
@@ -10,7 +10,8 @@ read_watersurfaces_hab(
     "20_processed/watersurfaces_hab/watersurfaces_hab.gpkg"),
   interpreted = FALSE,
   version = c("watersurfaces_hab_v6", "watersurfaces_hab_v5", "watersurfaces_hab_v4",
-    "watersurfaces_hab_v3", "watersurfaces_hab_v2", "watersurfaces_hab_v1")
+    "watersurfaces_hab_v3", "watersurfaces_hab_v2", "watersurfaces_hab_v1",
+    "watersurfaces_hab_v6.1_interim")
 )
 }
 \arguments{


### PR DESCRIPTION
Updated code and documentation for use with the intermediate version 2024 v99 interim of the habitatmap (March 2025):

- read_habitatmap_stdized
- read_habitatmap_terr
- read_watersurfaces_hab

Only minimal changes, no specific warnings yet for users loading the interim version (but I added a comment in this [issue](https://github.com/inbo/n2khab/issues/113#issuecomment-2948321909) so we can address this in a more systematical way later)
