### PR TITLE
read_*(): make docs for version arg function dependent

### DIFF
--- a/R/GRTSmh.R
+++ b/R/GRTSmh.R
@@ -285,7 +285,7 @@ convert_base4frac_to_dec <-
 #' @param brick Logical; determines whether the single- or ten-layered
 #' SpatRaster is returned. See the Details section.
 #'
-#' @inheritParams read_habitatmap_stdized
+#' @inheritParams read_habitatmap
 #'
 #' @return
 #' A single- or a ten-layered SpatRaster object, always with 21041043
@@ -425,7 +425,7 @@ read_GRTSmh <-
 #' So, what really matters is only the notation with many digits, to be
 #' \emph{regarded} as a base 4 fraction.
 #'
-#' @inheritParams read_habitatmap_stdized
+#' @inheritParams read_habitatmap
 #'
 #' @return
 #' A SpatRaster with 21041043 cells.

--- a/R/read_admin_areas.R
+++ b/R/read_admin_areas.R
@@ -24,7 +24,7 @@
 #' It is also used to determine \code{file} if that argument is not specified,
 #' in order to select the right data file(s) from the \code{n2khab_data} folder.
 #'
-#' @inheritParams read_habitatmap_stdized
+#' @inheritParams read_habitatmap
 #'
 #' @return
 #' A Simple feature collection of geometry type \code{MULTIPOLYGON} or

--- a/R/read_ecoregions.R
+++ b/R/read_ecoregions.R
@@ -17,7 +17,7 @@
 #' Apart from the label, there is no complementary information between
 #' \code{polygon_code} and \code{polygon_id}.
 #'
-#' @inheritParams read_habitatmap_stdized
+#' @inheritParams read_habitatmap
 #'
 #' @return
 #' A Simple feature collection of geometry type \code{MULTIPOLYGON}.

--- a/R/read_habitatdata.R
+++ b/R/read_habitatdata.R
@@ -495,7 +495,7 @@ read_watersurfaces_hab <-
 #' geometries (with GEOS as backend).
 #' Defaults to \code{FALSE}.
 #'
-#' @inheritParams read_habitatmap_stdized
+#' @inheritParams read_habitatmap
 #'
 #' @return
 #' A Simple feature collection of
@@ -986,6 +986,8 @@ read_watersurfaces <-
 #' \code{\link[sf:st_make_valid]{sf::st_make_valid()}} is used to fix
 #' geometries (with GEOS as backend).
 #' Defaults to \code{FALSE}.
+#' @param version Version ID of the data source.
+#' Defaults to the latest available version defined by the package.
 #'
 #' @inheritParams read_habitatmap_stdized
 #'
@@ -1473,7 +1475,7 @@ read_habitatmap_terr <-
 #' @param source_text Logical, defaults to \code{FALSE}.
 #' If \code{TRUE}, a list is returned (see \emph{Value}).
 #'
-#' @inheritParams read_habitatmap_stdized
+#' @inheritParams read_habitatmap
 #'
 #' @return
 #' With \code{source_text = FALSE} (default): a Simple feature collection of
@@ -1667,7 +1669,7 @@ read_habitatstreams <-
 #' centroid, their area attribute is summed (if all values are known)
 #' and for other attributes the maximum value is returned.
 #'
-#' @inheritParams read_habitatmap_stdized
+#' @inheritParams read_habitatmap
 #'
 #' @return
 #' A Simple feature collection of
@@ -1902,7 +1904,7 @@ read_habitatsprings <-
 #' @param bibtex If \code{TRUE}, all that happens is bibliographic references
 #' being printed to the console, formatted for usage in a BibTeX file (`*.bib`).
 #'
-#' @inheritParams read_habitatmap_stdized
+#' @inheritParams read_habitatmap
 #'
 #' @return
 #' Depending on the arguments, one of:

--- a/R/read_raster_runif.R
+++ b/R/read_raster_runif.R
@@ -18,7 +18,7 @@
 #' the \href{https://github.com/inbo/n2khab-preprocessing}{
 #' n2khab-preprocessing} repository.
 #'
-#' @inheritParams read_habitatmap_stdized
+#' @inheritParams read_habitatmap
 #'
 #' @return
 #' A SpatRaster.

--- a/R/read_shallowgroundwater.R
+++ b/R/read_shallowgroundwater.R
@@ -26,7 +26,7 @@
 #' \href{https://github.com/inbo/n2khab-preprocessing}{n2khab-preprocessing}
 #' repository.
 #'
-#' @inheritParams read_habitatmap_stdized
+#' @inheritParams read_habitatmap
 #'
 #' @return
 #' A Simple feature collection of geometry type \code{MULTIPOLYGON}.

--- a/R/read_watercourses.R
+++ b/R/read_watercourses.R
@@ -59,7 +59,7 @@
 #' \code{"points"}.
 #' If set, either the \code{lines} or the \code{points} object will be
 #' returned, respectively.
-#' @inheritParams read_habitatmap_stdized
+#' @inheritParams read_habitatmap
 #'
 #' @return
 #' By default, a list of two \code{sf} objects (see 'Description').

--- a/man/read_habitatmap.Rd
+++ b/man/read_habitatmap.Rd
@@ -35,9 +35,7 @@ geometries (with GEOS as backend).
 Defaults to \code{FALSE}.}
 
 \item{version}{Version ID of the data source.
-Defaults to the latest available version defined by the package.
-Versions with the 'interim' suffix are designed to be used within the Research
-Institute for Nature and Forest (INBO) only.}
+Defaults to the latest available version defined by the package.}
 }
 \value{
 A Simple feature collection of

--- a/man/read_habitatquarries.Rd
+++ b/man/read_habitatquarries.Rd
@@ -31,9 +31,7 @@ references (element \code{extra_references}).}
 being printed to the console, formatted for usage in a BibTeX file (\verb{*.bib}).}
 
 \item{version}{Version ID of the data source.
-Defaults to the latest available version defined by the package.
-Versions with the 'interim' suffix are designed to be used within the Research
-Institute for Nature and Forest (INBO) only.}
+Defaults to the latest available version defined by the package.}
 }
 \value{
 Depending on the arguments, one of:

--- a/man/read_habitatsprings.Rd
+++ b/man/read_habitatsprings.Rd
@@ -31,9 +31,7 @@ centroid, their area attribute is summed (if all values are known)
 and for other attributes the maximum value is returned.}
 
 \item{version}{Version ID of the data source.
-Defaults to the latest available version defined by the package.
-Versions with the 'interim' suffix are designed to be used within the Research
-Institute for Nature and Forest (INBO) only.}
+Defaults to the latest available version defined by the package.}
 }
 \value{
 A Simple feature collection of

--- a/man/read_raster_runif.Rd
+++ b/man/read_raster_runif.Rd
@@ -18,9 +18,7 @@ sequentially climbing up 0 to 10 levels in the file system hierarchy,
 starting from the working directory.}
 
 \item{version}{Version ID of the data source.
-Defaults to the latest available version defined by the package.
-Versions with the 'interim' suffix are designed to be used within the Research
-Institute for Nature and Forest (INBO) only.}
+Defaults to the latest available version defined by the package.}
 }
 \value{
 A SpatRaster.

--- a/man/read_watercourse_100mseg.Rd
+++ b/man/read_watercourse_100mseg.Rd
@@ -26,9 +26,7 @@ If set, either the \code{lines} or the \code{points} object will be
 returned, respectively.}
 
 \item{version}{Version ID of the data source.
-Defaults to the latest available version defined by the package.
-Versions with the 'interim' suffix are designed to be used within the Research
-Institute for Nature and Forest (INBO) only.}
+Defaults to the latest available version defined by the package.}
 }
 \value{
 By default, a list of two \code{sf} objects (see 'Description').

--- a/man/read_watersurfaces.Rd
+++ b/man/read_watersurfaces.Rd
@@ -39,9 +39,7 @@ geometries (with GEOS as backend).
 Defaults to \code{FALSE}.}
 
 \item{version}{Version ID of the data source.
-Defaults to the latest available version defined by the package.
-Versions with the 'interim' suffix are designed to be used within the Research
-Institute for Nature and Forest (INBO) only.}
+Defaults to the latest available version defined by the package.}
 }
 \value{
 A Simple feature collection of


### PR DESCRIPTION
Only a few functions effectively support interim versions, so it seems better to avoid referring to interim versions in the documentation of other functions.